### PR TITLE
Remove filter function if device is nothing

### DIFF
--- a/src/parameters/update_parameters.jl
+++ b/src/parameters/update_parameters.jl
@@ -64,7 +64,11 @@ function _update_parameter_values!(
     multiplier_id = get_time_series_multiplier_id(attributes)
     template = get_template(model)
     device_model = get_model(template, V)
-    filter_func = get_attribute(device_model, "filter_function")
+    if isnothing(device_model)
+        filter_func = nothing
+    else
+        filter_func = get_attribute(device_model, "filter_function")
+    end
     components = get_available_components(V, get_system(model), filter_func)
     ts_uuids = Set{String}()
     for component in components


### PR DESCRIPTION
This is an issue with the extensions, that can have decision models into device models in a simulation on which the decision model does not define any device model.