### PR TITLE
Speedup reading of results

### DIFF
--- a/src/PowerSimulations.jl
+++ b/src/PowerSimulations.jl
@@ -452,6 +452,7 @@ include("core/cache_utils.jl")
 include("core/optimizer_stats.jl")
 include("core/dataset.jl")
 include("core/dataset_container.jl")
+include("core/results_by_time.jl")
 
 include("core/optimization_container.jl")
 include("core/store_common.jl")
@@ -496,9 +497,9 @@ include("simulation/simulation_store_params.jl")
 include("simulation/hdf_simulation_store.jl")
 include("simulation/in_memory_simulation_store.jl")
 include("simulation/simulation_problem_results.jl")
-include("simulation/realized_meta.jl")
 include("simulation/decision_model_simulation_results.jl")
 include("simulation/emulation_model_simulation_results.jl")
+include("simulation/realized_meta.jl")
 include("simulation/simulation_partitions.jl")
 include("simulation/simulation_partition_results.jl")
 include("simulation/simulation_sequence.jl")
@@ -574,5 +575,13 @@ include("utils/powersystems_utils.jl")
 include("utils/recorder_events.jl")
 include("utils/datetime_utils.jl")
 include("utils/generate_valid_formulations.jl")
+
+# TODO: These exist for backward compatibility and need to be deprecated and removed.
+read_aux_variables_with_keys(args...; kwargs...) =
+    read_results_with_keys(args...; kwargs...)
+read_duals_with_keys(args...; kwargs...) = read_results_with_keys(args...; kwargs...)
+read_expressions_with_keys(args...; kwargs...) = read_results_with_keys(args...; kwargs...)
+read_parameters_with_keys(args...; kwargs...) = read_results_with_keys(args...; kwargs...)
+read_variables_with_keys(args...; kwargs...) = read_results_with_keys(args...; kwargs...)
 
 end

--- a/src/core/dataset.jl
+++ b/src/core/dataset.jl
@@ -167,13 +167,13 @@ function get_last_updated_timestamp(s::HDF5Dataset)
 end
 
 function get_value_timestamp(s::HDF5Dataset, date::Dates.DateTime)
+    error("Not implemented for HDF5Dataset. Required if it is used for simulation state.")
     # TODO: This code is broken because timestamps is not a field.
-    # The function is called for InMemoryDataset but not HDF5Dataset.
-    s_index = find_timestamp_index(s.timestamps, date)
-    if isnothing(s_index)
-        error("Request time stamp $date not in the state")
-    end
-    return s.initial_timestamp + s.resolution * (s_index - 1)
+    #s_index = find_timestamp_index(s.timestamps, date)
+    #if isnothing(s_index)
+    #    error("Request time stamp $date not in the state")
+    #end
+    #return s.initial_timestamp + s.resolution * (s_index - 1)
 end
 
 function set_value!(s::HDF5Dataset, vals, index::Int)

--- a/src/core/dataset.jl
+++ b/src/core/dataset.jl
@@ -59,7 +59,7 @@ function InMemoryDataset(values::DenseAxisArray{Float64, 2})
     )
 end
 
-Base.length(s::InMemoryDataset) = size(s.values)[2]
+get_num_rows(s::InMemoryDataset) = size(s.values)[2]
 
 function make_system_state(
     values::DenseAxisArray{Float64, 2},
@@ -140,10 +140,6 @@ mutable struct HDF5Dataset <: AbstractDataset
             update_timestamp, column_names)
     end
 end
-
-#Base.length(s::HDF5Dataset) = size(s.values)[1]  # TODO DT: what about the 3-dim case?
-# Not getting called by tests
-Base.length(s::HDF5Dataset) = error("die")
 
 HDF5Dataset(values, column_dataset, resolution, initial_time) =
     HDF5Dataset(

--- a/src/core/dataset.jl
+++ b/src/core/dataset.jl
@@ -1,6 +1,5 @@
 abstract type AbstractDataset end
 
-Base.length(s::AbstractDataset) = size(s.values)[1]
 get_data_resolution(s::AbstractDataset)::Dates.Millisecond = s.resolution
 get_last_recorded_row(s::AbstractDataset) = s.last_recorded_row
 
@@ -21,8 +20,9 @@ end
 
 # Values field is accessed with dot syntax to avoid type instability
 
-mutable struct DataFrameDataset <: AbstractDataset
-    values::DataFrames.DataFrame
+mutable struct InMemoryDataset <: AbstractDataset
+    "Data with dimensions (column names, row indexes)"
+    values::DenseAxisArray{Float64, 2}
     # We use Array here to allow for overwrites when updating the state
     timestamps::Vector{Dates.DateTime}
     # Resolution is needed because AbstractDataset might have just one row
@@ -32,13 +32,13 @@ mutable struct DataFrameDataset <: AbstractDataset
     update_timestamp::Dates.DateTime
 end
 
-function DataFrameDataset(
-    values::DataFrames.DataFrame,
+function InMemoryDataset(
+    values::DenseAxisArray{Float64, 2},
     timestamps::Vector{Dates.DateTime},
     resolution::Dates.Millisecond,
     end_of_step_index::Int,
 )
-    return DataFrameDataset(
+    return InMemoryDataset(
         values,
         timestamps,
         resolution,
@@ -48,8 +48,8 @@ function DataFrameDataset(
     )
 end
 
-function DataFrameDataset(values::DataFrames.DataFrame)
-    return DataFrameDataset(
+function InMemoryDataset(values::DenseAxisArray{Float64, 2})
+    return InMemoryDataset(
         values,
         Vector{Dates.DateTime}(),
         Dates.Second(0.0),
@@ -59,41 +59,42 @@ function DataFrameDataset(values::DataFrames.DataFrame)
     )
 end
 
+Base.length(s::InMemoryDataset) = size(s.values)[2]
+
 function make_system_state(
-    values::DataFrames.DataFrame,
+    values::DenseAxisArray{Float64, 2},
     timestamp::Dates.DateTime,
     resolution::Dates.Millisecond,
 )
-    return DataFrameDataset(values, [timestamp], resolution, 0, 1, UNSET_INI_TIME)
+    return InMemoryDataset(values, [timestamp], resolution, 0, 1, UNSET_INI_TIME)
 end
 
-function get_dataset_value(s::DataFrameDataset, date::Dates.DateTime)
+function get_dataset_value(s::InMemoryDataset, date::Dates.DateTime)
     s_index = find_timestamp_index(s.timestamps, date)
     if isnothing(s_index)
         error("Request time stamp $date not in the state")
     end
-    return s.values[s_index, :]
+    return s.values[:, s_index]
 end
 
-function get_column_names(::OptimizationContainerKey, s::DataFrameDataset)
-    return DataFrames.names(s.values)
-end
+get_column_names(s::InMemoryDataset) = axes(s.values)[1]
+get_column_names(::OptimizationContainerKey, s::InMemoryDataset) = get_column_names(s)
 
-function get_last_recorded_value(s::DataFrameDataset)
+function get_last_recorded_value(s::InMemoryDataset)
     if get_last_recorded_row(s) == 0
         error("The Dataset hasn't been written yet")
     end
-    return s.values[get_last_recorded_row(s), :]
+    return s.values[:, get_last_recorded_row(s)]
 end
 
-function get_end_of_step_timestamp(s::DataFrameDataset)
+function get_end_of_step_timestamp(s::InMemoryDataset)
     return s.timestamps[s.end_of_step_index]
 end
 
 """
 Return the timestamp from most recent data row updated in the dataset. This value may not be the same as the result from `get_update_timestamp`
 """
-function get_last_updated_timestamp(s::DataFrameDataset)
+function get_last_updated_timestamp(s::InMemoryDataset)
     last_recorded_row = get_last_recorded_row(s)
     if last_recorded_row == 0
         return UNSET_INI_TIME
@@ -101,7 +102,7 @@ function get_last_updated_timestamp(s::DataFrameDataset)
     return s.timestamps[last_recorded_row]
 end
 
-function get_value_timestamp(s::DataFrameDataset, date::Dates.DateTime)
+function get_value_timestamp(s::InMemoryDataset, date::Dates.DateTime)
     s_index = find_timestamp_index(s.timestamps, date)
     if isnothing(s_index)
         error("Request time stamp $date not in the state")
@@ -109,14 +110,13 @@ function get_value_timestamp(s::DataFrameDataset, date::Dates.DateTime)
     return s.timestamps[s_index]
 end
 
-function set_value!(s::DataFrameDataset, vals, index::Int)
-    setindex!(s.values, vals, index, :)
+function set_value!(s::InMemoryDataset, vals::DenseAxisArray{Float64, 2}, index::Int)
+    s.values[:, index] = vals[:, index]
     return
 end
 
-function set_value!(s::DataFrameDataset, vals::DataFrames.DataFrame, index::Int)
-    @assert_op size(vals)[1] == 1
-    set_value!(s, vals[1, :], index)
+function set_value!(s::InMemoryDataset, vals::DenseAxisArray{Float64, 1}, index::Int)
+    s.values[:, index] = vals
     return
 end
 
@@ -129,14 +129,35 @@ mutable struct HDF5Dataset <: AbstractDataset
     resolution::Dates.Millisecond
     initial_timestamp::Dates.DateTime
     update_timestamp::Dates.DateTime
+    column_names::Vector{String}
+
+    function HDF5Dataset(values, column_dataset, write_index, last_recorded_row, resolution,
+        initial_timestamp,
+        update_timestamp, column_names,
+    )
+        new(values, column_dataset, write_index, last_recorded_row, resolution,
+            initial_timestamp,
+            update_timestamp, column_names)
+    end
 end
+
+#Base.length(s::HDF5Dataset) = size(s.values)[1]  # TODO DT: what about the 3-dim case?
+# Not getting called by tests
+Base.length(s::HDF5Dataset) = error("die")
 
 HDF5Dataset(values, column_dataset, resolution, initial_time) =
-    HDF5Dataset(values, column_dataset, 1, 0, resolution, initial_time, UNSET_INI_TIME)
+    HDF5Dataset(
+        values,
+        column_dataset,
+        1,
+        0,
+        resolution,
+        initial_time,
+        UNSET_INI_TIME,
+        column_dataset[:],
+    )
 
-function get_column_names(::OptimizationContainerKey, s::HDF5Dataset)
-    return s.column_dataset[:]
-end
+get_column_names(::OptimizationContainerKey, s::HDF5Dataset) = s.column_names
 
 """
 Return the timestamp from most recent data row updated in the dataset. This value may not be the same as the result from `get_update_timestamp`
@@ -150,6 +171,8 @@ function get_last_updated_timestamp(s::HDF5Dataset)
 end
 
 function get_value_timestamp(s::HDF5Dataset, date::Dates.DateTime)
+    # TODO: This code is broken because timestamps is not a field.
+    # The function is called for InMemoryDataset but not HDF5Dataset.
     s_index = find_timestamp_index(s.timestamps, date)
     if isnothing(s_index)
         error("Request time stamp $date not in the state")

--- a/src/core/dataset_container.jl
+++ b/src/core/dataset_container.jl
@@ -27,23 +27,23 @@ function Base.empty!(container::DatasetContainer)
     return
 end
 
-function get_duals_values(container::DatasetContainer{DataFrameDataset})
+function get_duals_values(container::DatasetContainer{InMemoryDataset})
     return container.duals
 end
 
-function get_aux_variables_values(container::DatasetContainer{DataFrameDataset})
+function get_aux_variables_values(container::DatasetContainer{InMemoryDataset})
     return container.aux_variables
 end
 
-function get_variables_values(container::DatasetContainer{DataFrameDataset})
+function get_variables_values(container::DatasetContainer{InMemoryDataset})
     return container.variables
 end
 
-function get_parameters_values(container::DatasetContainer{DataFrameDataset})
+function get_parameters_values(container::DatasetContainer{InMemoryDataset})
     return container.parameters
 end
 
-function get_expression_values(container::DatasetContainer{DataFrameDataset})
+function get_expression_values(container::DatasetContainer{InMemoryDataset})
     return container.expressions
 end
 
@@ -133,7 +133,6 @@ function get_dataset(
     return get_dataset(container, ExpressionKey(T, U))
 end
 
-# Get dataset values is currently type unstable since the values field could be a DF
 function get_dataset_values(container::DatasetContainer, key::OptimizationContainerKey)
     return get_dataset(container, key).values
 end

--- a/src/core/optimization_container.jl
+++ b/src/core/optimization_container.jl
@@ -939,7 +939,7 @@ function get_constraint(
 end
 
 function read_duals(container::OptimizationContainer)
-    return Dict(k => axis_array_to_dataframe(v, k) for (k, v) in get_duals(container))
+    return Dict(k => to_dataframe(jump_value.(v), k) for (k, v) in get_duals(container))
 end
 
 ##################################### Parameter Container ##################################
@@ -1203,9 +1203,9 @@ function read_parameters(container::OptimizationContainer)
     for (k, v) in parameters
         # TODO: all functions similar to calculate_parameter_values should be in one
         # place and be consistent in behavior.
-        #params_dict[k] = axis_array_to_dataframe(calculate_parameter_values(v))
-        param_array = axis_array_to_dataframe(get_parameter_values(v), k)
-        multiplier_array = axis_array_to_dataframe(get_multiplier_array(v), k)
+        #params_dict[k] = to_dataframe(calculate_parameter_values(v))
+        param_array = to_dataframe(get_parameter_values(v), k)
+        multiplier_array = to_dataframe(get_multiplier_array(v), k)
         params_dict[k] = _calculate_parameter_values(k, param_array, multiplier_array)
     end
     return params_dict
@@ -1322,7 +1322,7 @@ end
 
 function read_expressions(container::OptimizationContainer)
     return Dict(
-        k => axis_array_to_dataframe(v, k) for (k, v) in get_expressions(container) if
+        k => to_dataframe(jump_value.(v), k) for (k, v) in get_expressions(container) if
         !(get_entry_type(k) <: SystemBalanceExpressions)
     )
 end
@@ -1395,7 +1395,7 @@ function write_initial_conditions_data!(
             if field == STORE_CONTAINER_PARAMETERS
                 ic_data_dict[key] = ic_container_dict[key]
             else
-                ic_data_dict[key] = axis_array_to_dataframe(field_container, key)
+                ic_data_dict[key] = to_dataframe(jump_value.(field_container), key)
             end
         end
     end

--- a/src/core/results_by_time.jl
+++ b/src/core/results_by_time.jl
@@ -12,7 +12,7 @@ end
 
 function _check_column_consistency(
     data::SortedDict{Dates.DateTime, DenseAxisArray{Float64, 2}},
-    cols,
+    cols::Vector{String},
 )
     for val in values(data)
         if axes(val)[1] != cols
@@ -21,7 +21,10 @@ function _check_column_consistency(
     end
 end
 
-function _check_column_consistency(data::SortedDict{Dates.DateTime, Matrix{Float64}}, cols)
+function _check_column_consistency(
+    data::SortedDict{Dates.DateTime, Matrix{Float64}},
+    cols::Vector{String},
+)
     for val in values(data)
         if size(val)[2] != length(cols)
             error("Mismatch in length of Matrix columns: $(size(val)[2]) $(length(cols))")
@@ -42,7 +45,12 @@ get_column_names(x::ResultsByTime) = x.column_names
 get_num_rows(::ResultsByTime{DenseAxisArray{Float64, 2}}, data) = length(axes(data)[2])
 get_num_rows(::ResultsByTime{Matrix{Float64}}, data) = size(data)[1]
 
-function _add_timestamps!(df::DataFrames.DataFrame, results::ResultsByTime, timestamp, data)
+function _add_timestamps!(
+    df::DataFrames.DataFrame,
+    results::ResultsByTime,
+    timestamp::Dates.DateTime,
+    data,
+)
     time_col =
         range(timestamp; length = get_num_rows(results, data), step = results.resolution)
     DataFrames.insertcols!(df, 1, :DateTime => time_col)

--- a/src/core/results_by_time.jl
+++ b/src/core/results_by_time.jl
@@ -1,0 +1,84 @@
+struct ResultsByTime{T}
+    key::OptimizationContainerKey
+    data::SortedDict{Dates.DateTime, T}
+    resolution::Dates.Period
+    column_names::Vector{String}
+end
+
+function ResultsByTime(key, data, resolution, column_names)
+    _check_column_consistency(data, column_names)
+    ResultsByTime(key, data, resolution, column_names)
+end
+
+function _check_column_consistency(
+    data::SortedDict{Dates.DateTime, DenseAxisArray{Float64, 2}},
+    cols,
+)
+    for val in values(data)
+        if axes(val)[1] != cols
+            error("Mismatch in DenseAxisArray column names: $(axes(val)[1]) $cols")
+        end
+    end
+end
+
+function _check_column_consistency(data::SortedDict{Dates.DateTime, Matrix{Float64}}, cols)
+    for val in values(data)
+        if size(val)[2] != length(cols)
+            error("Mismatch in length of Matrix columns: $(size(val)[2]) $(length(cols))")
+        end
+    end
+end
+
+# This struct behaves like a dict, delegating to its 'data' field.
+Base.length(res::ResultsByTime) = length(res.data)
+Base.iterate(res::ResultsByTime) = iterate(res.data)
+Base.iterate(res::ResultsByTime, state) = iterate(res.data, state)
+Base.getindex(res::ResultsByTime, i) = getindex(res.data, i)
+Base.setindex!(res::ResultsByTime, v, i) = setindex!(res.data, v, i)
+Base.firstindex(res::ResultsByTime) = firstindex(res.data)
+Base.lastindex(res::ResultsByTime) = lastindex(res.data)
+
+get_column_names(x::ResultsByTime) = x.column_names
+get_num_rows(::ResultsByTime{DenseAxisArray{Float64, 2}}, data) = length(axes(data)[2])
+get_num_rows(::ResultsByTime{Matrix{Float64}}, data) = size(data)[1]
+
+function _add_timestamps!(df::DataFrames.DataFrame, results::ResultsByTime, timestamp, data)
+    time_col =
+        range(timestamp; length = get_num_rows(results, data), step = results.resolution)
+    DataFrames.insertcols!(df, 1, :DateTime => time_col)
+end
+
+function make_dataframe(
+    results::ResultsByTime{DenseAxisArray{Float64, 2}},
+    timestamp::Dates.DateTime,
+)
+    array = results.data[timestamp]
+    df = DataFrames.DataFrame(permutedims(array.data), axes(array)[1])
+    _add_timestamps!(df, results, timestamp, array)
+    return df
+end
+
+function make_dataframe(results::ResultsByTime{Matrix{Float64}}, timestamp::Dates.DateTime)
+    array = results.data[timestamp]
+    df = DataFrames.DataFrame(array, results.column_names)
+    _add_timestamps!(df, results, timestamp, array)
+    return df
+end
+
+function make_dataframes(results::ResultsByTime)
+    return SortedDict(k => make_dataframe(results, k) for k in keys(results.data))
+end
+
+struct ResultsByKeyAndTime
+    "Contains all keys stored in the model."
+    result_keys::Vector{OptimizationContainerKey}
+    "Contains the results that have been read from the store and cached."
+    cached_results::Dict{OptimizationContainerKey, ResultsByTime}
+end
+
+ResultsByKeyAndTime(result_keys) = ResultsByKeyAndTime(
+    collect(result_keys),
+    Dict{OptimizationContainerKey, ResultsByTime}(),
+)
+
+Base.empty!(res::ResultsByKeyAndTime) = empty!(res.cached_results)

--- a/src/core/store_common.jl
+++ b/src/core/store_common.jl
@@ -96,11 +96,7 @@ function write_model_parameter_results!(
            should_export_parameter(export_params[:exports], index, model_name, key)
             resolution = export_params[:resolution]
             file_type = export_params[:file_type]
-            # TODO DT: why was jump_value being called again?
-            # (first time was in calculate_parameter_values)
-            # Was it always a noop?
             df = to_dataframe(data, key)
-            #df = to_dataframe(jump_value.(data), key)
             time_col = range(index; length = horizon, step = resolution)
             DataFrames.insertcols!(df, 1, :DateTime => time_col)
             export_result(file_type, exports_path, key, index, df)

--- a/src/core/store_common.jl
+++ b/src/core/store_common.jl
@@ -53,14 +53,15 @@ function write_model_dual_results!(
 
     for (key, constraint) in get_duals(container)
         !should_write_resulting_value(key) && continue
-        write_result!(store, model_name, key, index, update_timestamp, constraint)
+        data = jump_value.(constraint)
+        write_result!(store, model_name, key, index, update_timestamp, data)
 
         if export_params !== nothing &&
            should_export_dual(export_params[:exports], index, model_name, key)
             horizon = export_params[:horizon]
             resolution = export_params[:resolution]
             file_type = export_params[:file_type]
-            df = axis_array_to_dataframe(constraint, key)
+            df = to_dataframe(jump_value.(constraint), key)
             time_col = range(index; length = horizon, step = resolution)
             DataFrames.insertcols!(df, 1, :DateTime => time_col)
             export_result(file_type, exports_path, key, index, df)
@@ -95,7 +96,11 @@ function write_model_parameter_results!(
            should_export_parameter(export_params[:exports], index, model_name, key)
             resolution = export_params[:resolution]
             file_type = export_params[:file_type]
-            df = axis_array_to_dataframe(data, key)
+            # TODO DT: why was jump_value being called again?
+            # (first time was in calculate_parameter_values)
+            # Was it always a noop?
+            df = to_dataframe(data, key)
+            #df = to_dataframe(jump_value.(data), key)
             time_col = range(index; length = horizon, step = resolution)
             DataFrames.insertcols!(df, 1, :DateTime => time_col)
             export_result(file_type, exports_path, key, index, df)
@@ -126,14 +131,15 @@ function write_model_variable_results!(
 
     for (key, variable) in variables
         !should_write_resulting_value(key) && continue
-        write_result!(store, model_name, key, index, update_timestamp, variable)
+        data = jump_value.(variable)
+        write_result!(store, model_name, key, index, update_timestamp, data)
 
         if export_params !== nothing &&
            should_export_variable(export_params[:exports], index, model_name, key)
             horizon = export_params[:horizon]
             resolution = export_params[:resolution]
             file_type = export_params[:file_type]
-            df = axis_array_to_dataframe(variable, key)
+            df = to_dataframe(data, key)
             time_col = range(index; length = horizon, step = resolution)
             DataFrames.insertcols!(df, 1, :DateTime => time_col)
             export_result(file_type, exports_path, key, index, df)
@@ -158,14 +164,15 @@ function write_model_aux_variable_results!(
 
     for (key, variable) in get_aux_variables(container)
         !should_write_resulting_value(key) && continue
-        write_result!(store, model_name, key, index, update_timestamp, variable)
+        data = jump_value.(variable)
+        write_result!(store, model_name, key, index, update_timestamp, data)
 
         if export_params !== nothing &&
            should_export_aux_variable(export_params[:exports], index, model_name, key)
             horizon = export_params[:horizon]
             resolution = export_params[:resolution]
             file_type = export_params[:file_type]
-            df = axis_array_to_dataframe(variable, key)
+            df = to_dataframe(data, key)
             time_col = range(index; length = horizon, step = resolution)
             DataFrames.insertcols!(df, 1, :DateTime => time_col)
             export_result(file_type, exports_path, key, index, df)
@@ -196,14 +203,15 @@ function write_model_expression_results!(
 
     for (key, expression) in expressions
         !should_write_resulting_value(key) && continue
-        write_result!(store, model_name, key, index, update_timestamp, expression)
+        data = jump_value.(expression)
+        write_result!(store, model_name, key, index, update_timestamp, data)
 
         if export_params !== nothing &&
            should_export_expression(export_params[:exports], index, model_name, key)
             horizon = export_params[:horizon]
             resolution = export_params[:resolution]
             file_type = export_params[:file_type]
-            df = axis_array_to_dataframe(expression, key)
+            df = to_dataframe(data, key)
             time_col = range(index; length = horizon, step = resolution)
             DataFrames.insertcols!(df, 1, :DateTime => time_col)
             export_result(file_type, exports_path, key, index, df)

--- a/src/operation/abstract_model_store.jl
+++ b/src/operation/abstract_model_store.jl
@@ -53,15 +53,6 @@ function read_results(store::AbstractModelStore, key; index = nothing)
     return read_results(store, field, key; index = index)
 end
 
-function read_results(
-    ::Type{DataFrames.DataFrame},
-    store::AbstractModelStore,
-    key;
-    index = nothing,
-)
-    return read_results(store, key; index = index)
-end
-
 function list_keys(store::AbstractModelStore, container_type)
     container = get_data_field(store, container_type)
     return collect(keys(container))

--- a/src/operation/decision_model.jl
+++ b/src/operation/decision_model.jl
@@ -463,7 +463,7 @@ end
 
 function update_parameters!(
     model::DecisionModel,
-    decision_states::DatasetContainer{DataFrameDataset},
+    decision_states::DatasetContainer{InMemoryDataset},
 )
     cost_function_unsynch(get_optimization_container(model))
     for key in keys(get_parameters(model))

--- a/src/operation/emulation_model.jl
+++ b/src/operation/emulation_model.jl
@@ -319,7 +319,7 @@ function update_parameters!(model::EmulationModel, store::EmulationModelStore)
     return
 end
 
-function update_parameters!(model::EmulationModel, data::DatasetContainer{DataFrameDataset})
+function update_parameters!(model::EmulationModel, data::DatasetContainer{InMemoryDataset})
     cost_function_unsynch(get_optimization_container(model))
     for key in keys(get_parameters(model))
         update_parameter_values!(model, key, data)

--- a/src/operation/operation_model_interface.jl
+++ b/src/operation/operation_model_interface.jl
@@ -315,24 +315,15 @@ function _list_names(model::OperationModel, container_type)
     return encode_keys_as_strings(list_keys(get_store(model), container_type))
 end
 
-function read_dual(model::OperationModel, key::ConstraintKey)
-    return read_results(get_store(model), key)
-end
+read_dual(model::OperationModel, key::ConstraintKey) = _read_results(model, key)
+read_parameter(model::OperationModel, key::ParameterKey) = _read_results(model, key)
+read_aux_variable(model::OperationModel, key::AuxVarKey) = _read_results(model, key)
+read_variable(model::OperationModel, key::VariableKey) = _read_results(model, key)
+read_expression(model::OperationModel, key::ExpressionKey) = _read_results(model, key)
 
-function read_parameter(model::OperationModel, key::ParameterKey)
-    return read_results(get_store(model), key)
-end
-
-function read_aux_variable(model::OperationModel, key::AuxVarKey)
-    return read_results(get_store(model), key)
-end
-
-function read_variable(model::OperationModel, key::VariableKey)
-    return read_results(get_store(model), key)
-end
-
-function read_expression(model::OperationModel, key::ExpressionKey)
-    return read_results(get_store(model), key)
+function _read_results(model::OperationModel, key::OptimizationContainerKey)
+    res = read_results(get_store(model), key)
+    return DataFrames.DataFrame(permutedims(res.data), axes(res)[1])
 end
 
 read_optimizer_stats(model::OperationModel) = read_optimizer_stats(get_store(model))

--- a/src/operation/problem_results.jl
+++ b/src/operation/problem_results.jl
@@ -301,9 +301,9 @@ end
 function _read_results(
     result_values::Dict{<:OptimizationContainerKey, DataFrames.DataFrame},
     container_keys,
-    timestamps,
+    timestamps::Vector{Dates.DateTime},
     time_ids,
-    base_power::Number,
+    base_power::Float64,
 )
     existing_keys = keys(result_values)
     container_keys = container_keys === nothing ? existing_keys : container_keys

--- a/src/parameters/update_parameters.jl
+++ b/src/parameters/update_parameters.jl
@@ -175,7 +175,7 @@ function _update_parameter_values!(
 
     state_data = get_dataset(state, get_attribute_key(attributes))
     state_timestamps = state_data.timestamps
-    max_state_index = length(state_data)
+    max_state_index = get_num_rows(state_data)
 
     state_data_index = find_timestamp_index(state_timestamps, current_time)
     sim_timestamps = range(current_time; step = resolution, length = time[end])
@@ -215,7 +215,7 @@ function _update_parameter_values!(
 
     state_data = get_dataset(state, get_attribute_key(attributes))
     state_timestamps = state_data.timestamps
-    max_state_index = length(state_data)
+    max_state_index = get_num_rows(state_data)
 
     state_data_index = find_timestamp_index(state_timestamps, current_time)
 
@@ -409,7 +409,7 @@ function update_parameter_values!(
     interval_time_steps = Int(get_interval(model.internal.store_parameters) / resolution)
     state_data = get_dataset(input, get_attribute_key(parameter_attributes))
     state_timestamps = state_data.timestamps
-    max_state_index = length(state_data)
+    max_state_index = get_num_rows(state_data)
 
     state_data_index = find_timestamp_index(state_timestamps, current_time)
     sim_timestamps = range(current_time; step = resolution, length = time[end])

--- a/src/simulation/decision_model_simulation_results.jl
+++ b/src/simulation/decision_model_simulation_results.jl
@@ -458,10 +458,13 @@ function load_results!(
     initial_time = initial_time === nothing ? first(get_timestamps(res)) : initial_time
     res.results_timestamps = _process_timestamps(res, initial_time, count)
     dual_keys = [_deserialize_key(ConstraintKey, res, x...) for x in duals]
-    parameter_keys = ParameterKey[_deserialize_key(ParameterKey, res, x...) for x in parameters]
+    parameter_keys =
+        ParameterKey[_deserialize_key(ParameterKey, res, x...) for x in parameters]
     variable_keys = VariableKey[_deserialize_key(VariableKey, res, x...) for x in variables]
-    aux_variable_keys = AuxVarKey[_deserialize_key(AuxVarKey, res, x...) for x in aux_variables]
-    expression_keys = ExpressionKey[_deserialize_key(ExpressionKey, res, x...) for x in expressions]
+    aux_variable_keys =
+        AuxVarKey[_deserialize_key(AuxVarKey, res, x...) for x in aux_variables]
+    expression_keys =
+        ExpressionKey[_deserialize_key(ExpressionKey, res, x...) for x in expressions]
     function merge_results(store)
         merge!(
             get_cached_variables(res),

--- a/src/simulation/decision_model_simulation_results.jl
+++ b/src/simulation/decision_model_simulation_results.jl
@@ -222,7 +222,7 @@ function _read_results(
     ::Type{T},
     res::SimulationProblemResults{DecisionModelSimulationResults},
     result_keys,
-    timestamps,
+    timestamps::Vector{Dates.DateTime},
     store::Union{Nothing, <:SimulationStore},
 ) where {T <: Union{Matrix{Float64}, DenseAxisArray{Float64, 2}}}
     isempty(result_keys) && return Dict{OptimizationContainerKey, ResultsByTime{T}}()
@@ -458,10 +458,10 @@ function load_results!(
     initial_time = initial_time === nothing ? first(get_timestamps(res)) : initial_time
     res.results_timestamps = _process_timestamps(res, initial_time, count)
     dual_keys = [_deserialize_key(ConstraintKey, res, x...) for x in duals]
-    parameter_keys = [_deserialize_key(ParameterKey, res, x...) for x in parameters]
-    variable_keys = [_deserialize_key(VariableKey, res, x...) for x in variables]
-    aux_variable_keys = [_deserialize_key(AuxVarKey, res, x...) for x in aux_variables]
-    expression_keys = [_deserialize_key(ExpressionKey, res, x...) for x in expressions]
+    parameter_keys = ParameterKey[_deserialize_key(ParameterKey, res, x...) for x in parameters]
+    variable_keys = VariableKey[_deserialize_key(VariableKey, res, x...) for x in variables]
+    aux_variable_keys = AuxVarKey[_deserialize_key(AuxVarKey, res, x...) for x in aux_variables]
+    expression_keys = ExpressionKey[_deserialize_key(ExpressionKey, res, x...) for x in expressions]
     function merge_results(store)
         merge!(
             get_cached_variables(res),

--- a/src/simulation/decision_model_simulation_results.jl
+++ b/src/simulation/decision_model_simulation_results.jl
@@ -1,10 +1,9 @@
-
 struct DecisionModelSimulationResults <: OperationModelSimulationResults
-    variables::FieldResultsByTime
-    duals::FieldResultsByTime
-    parameters::FieldResultsByTime
-    aux_variables::FieldResultsByTime
-    expressions::FieldResultsByTime
+    variables::ResultsByKeyAndTime
+    duals::ResultsByKeyAndTime
+    parameters::ResultsByKeyAndTime
+    aux_variables::ResultsByKeyAndTime
+    expressions::ResultsByKeyAndTime
     forecast_horizon::Int
     container_key_lookup::Dict{String, OptimizationContainerKey}
 end
@@ -20,12 +19,6 @@ function SimulationProblemResults(
     kwargs...,
 )
     name = Symbol(model_name)
-    variables = list_decision_model_keys(store, name, STORE_CONTAINER_VARIABLES)
-    parameters = list_decision_model_keys(store, name, STORE_CONTAINER_PARAMETERS)
-    duals = list_decision_model_keys(store, name, STORE_CONTAINER_DUALS)
-    aux_variables = list_decision_model_keys(store, name, STORE_CONTAINER_AUX_VARIABLES)
-    expressions = list_decision_model_keys(store, name, STORE_CONTAINER_EXPRESSIONS)
-
     return SimulationProblemResults{DecisionModelSimulationResults}(
         store,
         model_name,
@@ -33,11 +26,21 @@ function SimulationProblemResults(
         sim_params,
         path,
         DecisionModelSimulationResults(
-            _fill_result_value_container(variables),
-            _fill_result_value_container(duals),
-            _fill_result_value_container(parameters),
-            _fill_result_value_container(aux_variables),
-            _fill_result_value_container(expressions),
+            ResultsByKeyAndTime(
+                list_decision_model_keys(store, name, STORE_CONTAINER_VARIABLES),
+            ),
+            ResultsByKeyAndTime(
+                list_decision_model_keys(store, name, STORE_CONTAINER_DUALS),
+            ),
+            ResultsByKeyAndTime(
+                list_decision_model_keys(store, name, STORE_CONTAINER_PARAMETERS),
+            ),
+            ResultsByKeyAndTime(
+                list_decision_model_keys(store, name, STORE_CONTAINER_AUX_VARIABLES),
+            ),
+            ResultsByKeyAndTime(
+                list_decision_model_keys(store, name, STORE_CONTAINER_EXPRESSIONS),
+            ),
             get_horizon(problem_params),
             container_key_lookup,
         );
@@ -45,71 +48,147 @@ function SimulationProblemResults(
     )
 end
 
-function Base.empty!(res::SimulationProblemResults{DecisionModelSimulationResults})
-    foreach(empty!, _get_dicts(res))
-    empty!(res.results_timestamps)
-    return
+function _list_containers(res::SimulationProblemResults{DecisionModelSimulationResults})
+    return (getfield(res.values, x).cached_results for x in get_container_fields(res))
 end
 
-Base.isempty(res::SimulationProblemResults{DecisionModelSimulationResults}) =
-    all(isempty, _get_dicts(res))
+function Base.empty!(res::SimulationProblemResults{DecisionModelSimulationResults})
+    foreach(empty!, _list_containers(res))
+    empty!(res.results_timestamps)
+end
+
+function Base.isempty(res::SimulationProblemResults{DecisionModelSimulationResults})
+    all(isempty, _list_containers(res))
+end
 
 # This returns the number of timestamps stored in all containers.
-Base.length(res::SimulationProblemResults{DecisionModelSimulationResults}) =
-    mapreduce(length, +, _get_dicts(res))
+function Base.length(res::SimulationProblemResults{DecisionModelSimulationResults})
+    return mapreduce(length, +, (y for x in _list_containers(res) for y in values(x)))
+end
 
-_get_dicts(res::SimulationProblemResults) =
-    (y for x in _get_containers(res) for y in values(x))
+list_aux_variable_keys(res::SimulationProblemResults{DecisionModelSimulationResults}) =
+    res.values.aux_variables.result_keys[:]
+list_dual_keys(res::SimulationProblemResults{DecisionModelSimulationResults}) =
+    res.values.duals.result_keys[:]
+list_expression_keys(res::SimulationProblemResults{DecisionModelSimulationResults}) =
+    res.values.expressions.result_keys[:]
+list_parameter_keys(res::SimulationProblemResults{DecisionModelSimulationResults}) =
+    res.values.parameters.result_keys[:]
+list_variable_keys(res::SimulationProblemResults{DecisionModelSimulationResults}) =
+    res.values.variables.result_keys[:]
+
+get_cached_aux_variables(res::SimulationProblemResults{DecisionModelSimulationResults}) =
+    res.values.aux_variables.cached_results
+get_cached_duals(res::SimulationProblemResults{DecisionModelSimulationResults}) =
+    res.values.duals.cached_results
+get_cached_expressions(res::SimulationProblemResults{DecisionModelSimulationResults}) =
+    res.values.expressions.cached_results
+get_cached_parameters(res::SimulationProblemResults{DecisionModelSimulationResults}) =
+    res.values.parameters.cached_results
+get_cached_variables(res::SimulationProblemResults{DecisionModelSimulationResults}) =
+    res.values.variables.cached_results
+
+get_cached_results(
+    res::SimulationProblemResults{DecisionModelSimulationResults},
+    ::AuxVarKey,
+) = get_cached_aux_variables(res)
+get_cached_results(
+    res::SimulationProblemResults{DecisionModelSimulationResults},
+    ::ConstraintKey,
+) = get_cached_duals(res)
+get_cached_results(
+    res::SimulationProblemResults{DecisionModelSimulationResults},
+    ::ExpressionKey,
+) = get_cached_expressions(res)
+get_cached_results(
+    res::SimulationProblemResults{DecisionModelSimulationResults},
+    ::ParameterKey,
+) = get_cached_parameters(res)
+get_cached_results(
+    res::SimulationProblemResults{DecisionModelSimulationResults},
+    ::VariableKey,
+) = get_cached_variables(res)
 
 function get_forecast_horizon(res::SimulationProblemResults{DecisionModelSimulationResults})
     return res.values.forecast_horizon
 end
 
 function _get_store_value(
+    ::Type{T},
     res::SimulationProblemResults{DecisionModelSimulationResults},
     container_keys::Vector{<:OptimizationContainerKey},
     timestamps,
     ::Nothing,
-)
+) where {T <: Union{Matrix{Float64}, DenseAxisArray{Float64, 2}}}
     simulation_store_path = joinpath(get_execution_path(res), "data_store")
     return open_store(HdfSimulationStore, simulation_store_path, "r") do store
-        _get_store_value(res, container_keys, timestamps, store)
+        _get_store_value(T, res, container_keys, timestamps, store)
     end
 end
 
 function _get_store_value(
-    res::SimulationProblemResults{DecisionModelSimulationResults},
+    ::Type{DenseAxisArray{Float64, 2}},
+    sim_results::SimulationProblemResults{DecisionModelSimulationResults},
     container_keys::Vector{<:OptimizationContainerKey},
     timestamps,
     store::SimulationStore,
 )
-    base_power = get_model_base_power(res)
-    results =
-        Dict{OptimizationContainerKey, SortedDict{Dates.DateTime, DataFrames.DataFrame}}()
-    model_name = Symbol(get_model_name(res))
-    resolution = get_resolution(res)
-    horizon = get_forecast_horizon(res)
+    base_power = get_model_base_power(sim_results)
+    results_by_key =
+        Dict{OptimizationContainerKey, ResultsByTime{DenseAxisArray{Float64, 2}}}()
+    model_name = Symbol(get_model_name(sim_results))
+    resolution = get_resolution(sim_results)
+
     for key in container_keys
-        _results = SortedDict{Dates.DateTime, DataFrames.DataFrame}()
+        results_by_time = ResultsByTime(
+            key,
+            SortedDict{Dates.DateTime, DenseAxisArray{Float64, 2}}(),
+            resolution,
+            get_column_names(store, DecisionModelIndexType, model_name, key),
+        )
         for ts in timestamps
-            out = read_result(DataFrames.DataFrame, store, model_name, key, ts)
+            array = read_result(DenseAxisArray, store, model_name, key, ts)
             if convert_result_to_natural_units(key)
-                out .*= base_power
+                array.data .*= base_power
             end
-            if size(out, 1) == horizon
-                time_col = range(ts; length = horizon, step = resolution)
-                DataFrames.insertcols!(out, 1, :DateTime => time_col)
-            else
-                @warn(
-                    "$(encode_key_as_string(key)) has a different horizon than the problem specification. Can't assign Time stamps to the resulting DataFrame."
-                )
-            end
-            _results[ts] = out
+            results_by_time[ts] = array
         end
-        results[key] = _results
+        results_by_key[key] = results_by_time
     end
 
-    return results
+    return results_by_key
+end
+
+function _get_store_value(
+    ::Type{Matrix{Float64}},
+    sim_results::SimulationProblemResults{DecisionModelSimulationResults},
+    container_keys::Vector{<:OptimizationContainerKey},
+    timestamps,
+    store::SimulationStore,
+)
+    base_power = get_model_base_power(sim_results)
+    results_by_key = Dict{OptimizationContainerKey, ResultsByTime{Matrix{Float64}}}()
+    model_name = Symbol(get_model_name(sim_results))
+    resolution = get_resolution(sim_results)
+
+    for key in container_keys
+        results_by_time = ResultsByTime{Matrix{Float64}}(
+            key,
+            SortedDict{Dates.DateTime, Matrix{Float64}}(),
+            resolution,
+            get_column_names(store, DecisionModelIndexType, model_name, key),
+        )
+        for ts in timestamps
+            array = read_result(Array, store, model_name, key, ts)
+            if convert_result_to_natural_units(key)
+                array .*= base_power
+            end
+            results_by_time[ts] = array
+        end
+        results_by_key[key] = results_by_time
+    end
+
+    return results_by_key
 end
 
 function _process_timestamps(
@@ -139,27 +218,28 @@ function _process_timestamps(
     return requested_range
 end
 
-function _read_variables(
+function _read_results(
+    ::Type{T},
     res::SimulationProblemResults{DecisionModelSimulationResults},
-    variable_keys,
+    result_keys,
     timestamps,
-    store,
-)
-    isempty(variable_keys) && return FieldResultsByTime()
+    store::Union{Nothing, <:SimulationStore},
+) where {T <: Union{Matrix{Float64}, DenseAxisArray{Float64, 2}}}
+    isempty(result_keys) && return Dict{OptimizationContainerKey, ResultsByTime{T}}()
+
     if store === nothing && res.store !== nothing
         # In this case we have an InMemorySimulationStore.
         store = res.store
     end
-    _validate_keys(keys(get_variables(res)), variable_keys)
-    same_timestamps = isempty(setdiff(res.results_timestamps, timestamps))
-    keys_with_values = [k for (k, v) in get_variables(res) if !isempty(v)]
-    same_keys = isempty([n for n in variable_keys if n ∉ keys_with_values])
-    if same_timestamps && same_keys
-        @debug "reading variables from SimulationsResults"
-        vals = filter(p -> (p.first ∈ variable_keys), get_variables(res))
+    existing_keys = list_result_keys(res, first(result_keys))
+    _validate_keys(existing_keys, result_keys)
+    cached_results = get_cached_results(res, first(result_keys))
+    if _are_results_cached(res, result_keys, timestamps, keys(cached_results))
+        @debug "reading results from SimulationsResults cache"
+        vals = Dict(k => cached_results[k] for k in result_keys)
     else
-        @debug "reading variables from data store"
-        vals = _get_store_value(res, variable_keys, timestamps, store)
+        @debug "reading results from data store"
+        vals = _get_store_value(T, res, result_keys, timestamps, store)
     end
     return vals
 end
@@ -191,27 +271,9 @@ function read_variable(
 )
     key = _deserialize_key(VariableKey, res, args...)
     timestamps = _process_timestamps(res, initial_time, count)
-    return _read_variables(res, [key], timestamps, store)[key]
-end
-
-function _read_duals(res::SimulationProblemResults, dual_keys, timestamps, store)
-    isempty(dual_keys) && return FieldResultsByTime()
-    if store === nothing && res.store !== nothing
-        # In this case we have an InMemorySimulationStore.
-        store = res.store
-    end
-    _validate_keys(keys(get_duals(res)), dual_keys)
-    same_timestamps = isempty(setdiff(res.results_timestamps, timestamps))
-    keys_with_values = [k for (k, v) in get_duals(res) if !isempty(v)]
-    same_keys = isempty([n for n in dual_keys if n ∉ keys_with_values])
-    if same_timestamps && same_keys
-        @debug "reading duals from SimulationsResults"
-        vals = filter(p -> (p.first ∈ dual_keys), get_duals(res))
-    else
-        @debug "reading duals from data store"
-        vals = _get_store_value(res, dual_keys, timestamps, store)
-    end
-    return vals
+    return make_dataframes(
+        _read_results(DenseAxisArray{Float64, 2}, res, [key], timestamps, store)[key],
+    )
 end
 
 """
@@ -234,27 +296,9 @@ function read_dual(
 )
     key = _deserialize_key(ConstraintKey, res, args...)
     timestamps = _process_timestamps(res, initial_time, count)
-    return _read_duals(res, [key], timestamps, store)[key]
-end
-
-function _read_parameters(res::SimulationProblemResults, parameter_keys, timestamps, store)
-    isempty(parameter_keys) && return FieldResultsByTime()
-    if store === nothing && res.store !== nothing
-        # In this case we have an InMemorySimulationStore.
-        store = res.store
-    end
-    _validate_keys(keys(get_parameters(res)), parameter_keys)
-    same_timestamps = isempty(setdiff(res.results_timestamps, timestamps))
-    parameters_with_values = [k for (k, v) in get_parameters(res) if !isempty(v)]
-    same_parameters = isempty([n for n in parameter_keys if n ∉ parameters_with_values])
-    if same_timestamps && same_parameters
-        @debug "reading parameters from SimulationsResults"
-        vals = filter(p -> (p.first ∈ parameter_keys), get_parameters(res))
-    else
-        @debug "reading parameters from data store"
-        vals = _get_store_value(res, parameter_keys, timestamps, store)
-    end
-    return vals
+    return make_dataframes(
+        _read_results(DenseAxisArray{Float64, 2}, res, [key], timestamps, store)[key],
+    )
 end
 
 """
@@ -270,39 +314,15 @@ Return the values for the requested parameter. It keeps requests when performing
 function read_parameter(
     res::SimulationProblemResults{DecisionModelSimulationResults},
     args...;
-    time_series_name = nothing,
     initial_time::Union{Nothing, Dates.DateTime} = nothing,
     count::Union{Int, Nothing} = nothing,
     store = nothing,
 )
     key = _deserialize_key(ParameterKey, res, args...)
     timestamps = _process_timestamps(res, initial_time, count)
-    return _read_parameters(res, [key], timestamps, store)[key]
-end
-
-function _read_aux_variables(
-    res::SimulationProblemResults,
-    aux_variable_keys,
-    timestamps,
-    store,
-)
-    isempty(aux_variable_keys) && return FieldResultsByTime()
-    if store === nothing && res.store !== nothing
-        # In this case we have an InMemorySimulationStore.
-        store = res.store
-    end
-    _validate_keys(keys(get_aux_variables(res)), aux_variable_keys)
-    same_timestamps = isempty(setdiff(res.results_timestamps, timestamps))
-    keys_with_values = [k for (k, v) in get_aux_variables(res) if !isempty(v)]
-    same_keys = isempty([n for n in aux_variable_keys if n ∉ keys_with_values])
-    if same_timestamps && same_keys
-        @debug "reading aux variables from SimulationsResults"
-        vals = filter(p -> (p.first ∈ aux_variable_keys), get_aux_variables(res))
-    else
-        @debug "reading aux variables from data store"
-        vals = _get_store_value(res, aux_variable_keys, timestamps, store)
-    end
-    return vals
+    return make_dataframes(
+        _read_results(DenseAxisArray{Float64, 2}, res, [key], timestamps, store)[key],
+    )
 end
 
 """
@@ -318,39 +338,15 @@ Return the values for the requested auxillary variables. It keeps requests when 
 function read_aux_variable(
     res::SimulationProblemResults{DecisionModelSimulationResults},
     args...;
-    time_series_name = nothing,
     initial_time::Union{Nothing, Dates.DateTime} = nothing,
     count::Union{Int, Nothing} = nothing,
     store = nothing,
 )
     key = _deserialize_key(AuxVarKey, res, args...)
     timestamps = _process_timestamps(res, initial_time, count)
-    return _read_aux_variables(res, [key], timestamps, store)[key]
-end
-
-function _read_expressions(
-    res::SimulationProblemResults,
-    expression_keys,
-    timestamps,
-    store,
-)
-    isempty(expression_keys) && return FieldResultsByTime()
-    if store === nothing && res.store !== nothing
-        # In this case we have an InMemorySimulationStore.
-        store = res.store
-    end
-    _validate_keys(keys(get_expressions(res)), expression_keys)
-    same_timestamps = isempty(setdiff(res.results_timestamps, timestamps))
-    keys_with_values = [k for (k, v) in get_expressions(res) if !isempty(v)]
-    same_keys = isempty([n for n in expression_keys if n ∉ keys_with_values])
-    if same_timestamps && same_keys
-        @debug "reading expressions from SimulationsResults"
-        vals = filter(p -> (p.first ∈ expression_keys), get_expressions(res))
-    else
-        @debug "reading expressions from data store"
-        vals = _get_store_value(res, expression_keys, timestamps, store)
-    end
-    return vals
+    return make_dataframes(
+        _read_results(DenseAxisArray{Float64, 2}, res, [key], timestamps, store)[key],
+    )
 end
 
 """
@@ -366,14 +362,15 @@ Return the values for the requested auxillary variables. It keeps requests when 
 function read_expression(
     res::SimulationProblemResults{DecisionModelSimulationResults},
     args...;
-    time_series_name = nothing,
     initial_time::Union{Nothing, Dates.DateTime} = nothing,
     count::Union{Int, Nothing} = nothing,
     store = nothing,
 )
     key = _deserialize_key(ExpressionKey, res, args...)
     timestamps = _process_timestamps(res, initial_time, count)
-    return _read_expressions(res, [key], timestamps, store)[key]
+    return make_dataframes(
+        _read_results(DenseAxisArray{Float64, 2}, res, [key], timestamps, store)[key],
+    )
 end
 
 function get_realized_timestamps(
@@ -407,64 +404,26 @@ function get_realized_timestamps(
     return requested_range
 end
 
-function read_variables_with_keys(
+function read_results_with_keys(
     res::SimulationProblemResults{DecisionModelSimulationResults},
-    variables::Vector{<:OptimizationContainerKey};
+    result_keys::Vector{<:OptimizationContainerKey};
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Int, Nothing} = nothing,
 )
     meta = RealizedMeta(res; start_time = start_time, len = len)
     timestamps = _process_timestamps(res, meta.start_time, meta.len)
-    result_values = _read_variables(res, variables, timestamps, nothing)
+    result_values = _read_results(Matrix{Float64}, res, result_keys, timestamps, nothing)
     return get_realization(result_values, meta)
 end
 
-function read_parameters_with_keys(
+function _are_results_cached(
     res::SimulationProblemResults{DecisionModelSimulationResults},
-    parameters::Vector{<:OptimizationContainerKey};
-    start_time::Union{Nothing, Dates.DateTime} = nothing,
-    len::Union{Int, Nothing} = nothing,
+    output_keys,
+    timestamps,
+    cached_keys,
 )
-    meta = RealizedMeta(res; start_time = start_time, len = len)
-    timestamps = _process_timestamps(res, meta.start_time, meta.len)
-    result_values = _read_parameters(res, parameters, timestamps, nothing)
-    return get_realization(result_values, meta)
-end
-
-function read_duals_with_keys(
-    res::SimulationProblemResults{DecisionModelSimulationResults},
-    duals::Vector{<:OptimizationContainerKey};
-    start_time::Union{Nothing, Dates.DateTime} = nothing,
-    len::Union{Int, Nothing} = nothing,
-)
-    meta = RealizedMeta(res; start_time = start_time, len = len)
-    timestamps = _process_timestamps(res, meta.start_time, meta.len)
-    result_values = _read_duals(res, duals, timestamps, nothing)
-    return get_realization(result_values, meta)
-end
-
-function read_aux_variables_with_keys(
-    res::SimulationProblemResults,
-    aux_variables::Vector{<:OptimizationContainerKey};
-    start_time::Union{Nothing, Dates.DateTime} = nothing,
-    len::Union{Int, Nothing} = nothing,
-)
-    meta = RealizedMeta(res; start_time = start_time, len = len)
-    timestamps = _process_timestamps(res, meta.start_time, meta.len)
-    result_values = _read_aux_variables(res, aux_variables, timestamps, nothing)
-    return get_realization(result_values, meta)
-end
-
-function read_expressions_with_keys(
-    res::SimulationProblemResults{DecisionModelSimulationResults},
-    expressions::Vector{<:OptimizationContainerKey};
-    start_time::Union{Nothing, Dates.DateTime} = nothing,
-    len::Union{Int, Nothing} = nothing,
-)
-    meta = RealizedMeta(res; start_time = start_time, len = len)
-    timestamps = _process_timestamps(res, meta.start_time, meta.len)
-    result_values = _read_expressions(res, expressions, timestamps, nothing)
-    return get_realization(result_values, meta)
+    return isempty(setdiff(timestamps, res.results_timestamps)) &&
+           isempty(setdiff(output_keys, cached_keys))
 end
 
 """
@@ -497,9 +456,7 @@ function load_results!(
     expressions = Vector{Tuple}(),
 )
     initial_time = initial_time === nothing ? first(get_timestamps(res)) : initial_time
-
     res.results_timestamps = _process_timestamps(res, initial_time, count)
-
     dual_keys = [_deserialize_key(ConstraintKey, res, x...) for x in duals]
     parameter_keys = [_deserialize_key(ParameterKey, res, x...) for x in parameters]
     variable_keys = [_deserialize_key(VariableKey, res, x...) for x in variables]
@@ -507,21 +464,54 @@ function load_results!(
     expression_keys = [_deserialize_key(ExpressionKey, res, x...) for x in expressions]
     function merge_results(store)
         merge!(
-            get_variables(res),
-            _read_variables(res, variable_keys, res.results_timestamps, store),
-        )
-        merge!(get_duals(res), _read_duals(res, dual_keys, res.results_timestamps, store))
-        merge!(
-            get_parameters(res),
-            _read_parameters(res, parameter_keys, res.results_timestamps, store),
-        )
-        merge!(
-            get_aux_variables(res),
-            _read_aux_variables(res, aux_variable_keys, res.results_timestamps, store),
+            get_cached_variables(res),
+            _read_results(
+                DenseAxisArray{Float64, 2},
+                res,
+                variable_keys,
+                res.results_timestamps,
+                store,
+            ),
         )
         merge!(
-            get_expressions(res),
-            _read_expressions(res, expression_keys, res.results_timestamps, store),
+            get_cached_duals(res),
+            _read_results(
+                DenseAxisArray{Float64, 2},
+                res,
+                dual_keys,
+                res.results_timestamps,
+                store,
+            ),
+        )
+        merge!(
+            get_cached_parameters(res),
+            _read_results(
+                DenseAxisArray{Float64, 2},
+                res,
+                parameter_keys,
+                res.results_timestamps,
+                store,
+            ),
+        )
+        merge!(
+            get_cached_aux_variables(res),
+            _read_results(
+                DenseAxisArray{Float64, 2},
+                res,
+                aux_variable_keys,
+                res.results_timestamps,
+                store,
+            ),
+        )
+        merge!(
+            get_cached_expressions(res),
+            _read_results(
+                DenseAxisArray{Float64, 2},
+                res,
+                expression_keys,
+                res.results_timestamps,
+                store,
+            ),
         )
     end
 

--- a/src/simulation/hdf_simulation_store.jl
+++ b/src/simulation/hdf_simulation_store.jl
@@ -519,10 +519,9 @@ function write_result!(
     key::OptimizationContainerKey,
     index::DecisionModelIndexType,
     ::Dates.DateTime,
-    data,
-)
+    data::DenseAxisArray{Float64, N, K},
+) where {N, K <: NTuple{N, Any}}
     output_cache = get_output_cache(store.cache, model_name, key)
-
     cur_size = get_size(store.cache)
     add_result!(output_cache, index, to_matrix(data), is_full(store.cache, cur_size))
 

--- a/src/simulation/hdf_simulation_store.jl
+++ b/src/simulation/hdf_simulation_store.jl
@@ -345,7 +345,7 @@ function read_result(
     if (ndims(data) < 2 || size(data)[1] == 1) && size(data)[2] != size(columns)[1]
         data = reshape(data, length(data), 1)
     end
-    return DataFrames.DataFrame(data, collect(columns); copycols = false)
+    return DataFrames.DataFrame(data, columns; copycols = false)
 end
 
 function read_result(
@@ -519,8 +519,8 @@ function write_result!(
     key::OptimizationContainerKey,
     index::DecisionModelIndexType,
     ::Dates.DateTime,
-    data::DenseAxisArray{Float64, N, K},
-) where {N, K <: NTuple{N, Any}}
+    data::DenseAxisArray{Float64, N, <: NTuple{N, Any}},
+) where N
     output_cache = get_output_cache(store.cache, model_name, key)
     cur_size = get_size(store.cache)
     add_result!(output_cache, index, to_matrix(data), is_full(store.cache, cur_size))

--- a/src/simulation/hdf_simulation_store.jl
+++ b/src/simulation/hdf_simulation_store.jl
@@ -175,12 +175,12 @@ function list_decision_model_keys(
     container_type::Symbol,
 )
     container = getfield(get_dm_data(store)[model], container_type)
-    return keys(container)
+    return collect(keys(container))
 end
 
 function list_emulation_model_keys(store::HdfSimulationStore, container_type::Symbol)
     container = getfield(get_em_data(store), container_type)
-    return keys(container)
+    return collect(keys(container))
 end
 
 function write_optimizer_stats!(
@@ -345,7 +345,7 @@ function read_result(
     if (ndims(data) < 2 || size(data)[1] == 1) && size(data)[2] != size(columns)[1]
         data = reshape(data, length(data), 1)
     end
-    return DataFrames.DataFrame(data, columns)
+    return DataFrames.DataFrame(data, collect(columns); copycols = false)
 end
 
 function read_result(
@@ -355,23 +355,29 @@ function read_result(
     key::OptimizationContainerKey,
     index::Union{DecisionModelIndexType, EmulationModelIndexType},
 )
-    data, columns = _read_data_columns(store, model_name, key, index)
+    if is_cached(store.cache, model_name, key, index)
+        data = read_result(store.cache, model_name, key, index)
+        columns = get_column_names(store, DecisionModelIndexType, model_name, key)
+    else
+        data, columns = _read_result(store, model_name, key, index)
+    end
     return DenseAxisArray(permutedims(data), columns, 1:size(data)[1])
 end
 
 function read_result(
-    ::Type{<:Array},
+    ::Type{Array},
     store::HdfSimulationStore,
     model_name::Symbol,
     key::OptimizationContainerKey,
     index::Union{DecisionModelIndexType, EmulationModelIndexType},
 )
     if is_cached(store.cache, model_name, key, index)
-        data = _read_result(store.cache, model_name, key, index)
+        data = read_result(store.cache, model_name, key, index)
     else
-        # PERF: If this will be commonly used then we need to remove reading of columns.
         data, _ = _read_result(store, model_name, key, index)
     end
+
+    return data
 end
 
 function read_results(
@@ -392,7 +398,28 @@ function read_results(
     end
     columns = get_column_names(key, dataset)
     @assert_op size(data)[2] == length(columns)
-    return DataFrames.DataFrame(data, columns)
+    return DenseAxisArray(permutedims(data), columns, 1:size(data)[1])
+end
+
+function get_column_names(
+    store::HdfSimulationStore,
+    ::Type{DecisionModelIndexType},
+    model_name::Symbol,
+    key::OptimizationContainerKey,
+)
+    !isopen(store) && throw(ArgumentError("store must be opened prior to reading"))
+    dataset = _get_dm_dataset(store, model_name, key)
+    return get_column_names(key, dataset)
+end
+
+function get_column_names(
+    store::HdfSimulationStore,
+    ::Type{EmulationModelIndexType},
+    key::OptimizationContainerKey,
+)
+    !isopen(store) && throw(ArgumentError("store must be opened prior to reading"))
+    dataset = _get_em_dataset(store, key)
+    return get_column_names(key, dataset)
 end
 
 function get_emulation_model_dataset_size(
@@ -400,12 +427,12 @@ function get_emulation_model_dataset_size(
     key::OptimizationContainerKey,
 )
     dataset = _get_em_dataset(store, key)
-    return size(dataset.values)
+    return size(dataset.values)[1]
 end
 
 function _read_result(
     store::HdfSimulationStore,
-    model_name::Symbol,
+    ::Symbol,
     key::OptimizationContainerKey,
     index::EmulationModelIndexType,
 )

--- a/src/simulation/hdf_simulation_store.jl
+++ b/src/simulation/hdf_simulation_store.jl
@@ -519,8 +519,8 @@ function write_result!(
     key::OptimizationContainerKey,
     index::DecisionModelIndexType,
     ::Dates.DateTime,
-    data::DenseAxisArray{Float64, N, <: NTuple{N, Any}},
-) where N
+    data::DenseAxisArray{Float64, N, <:NTuple{N, Any}},
+) where {N}
     output_cache = get_output_cache(store.cache, model_name, key)
     cur_size = get_size(store.cache)
     add_result!(output_cache, index, to_matrix(data), is_full(store.cache, cur_size))

--- a/src/simulation/realized_meta.jl
+++ b/src/simulation/realized_meta.jl
@@ -47,41 +47,48 @@ function RealizedMeta(
 end
 
 function get_realization(
-    result_values::Dict{
-        OptimizationContainerKey,
-        SortedDict{Dates.DateTime, DataFrames.DataFrame},
-    },
+    results::Dict{OptimizationContainerKey, ResultsByTime{Matrix{Float64}}},
     meta::RealizedMeta,
 )
     realized_values = Dict{OptimizationContainerKey, DataFrames.DataFrame}()
-    for (key, result_value) in result_values
-        results_concat = Dict{Symbol, Vector{Float64}}()
-        for (step, (t, df)) in enumerate(result_value)
+    lk = ReentrantLock()
+    num_rows = length(meta.realized_timestamps)
+    start = time()
+    Threads.@threads for key in collect(keys(results))
+        results_by_time = results[key]
+        columns = get_column_names(results_by_time)
+        num_cols = length(columns)
+        matrix = Matrix{Float64}(undef, num_rows, num_cols)
+        for (step, (_, array)) in enumerate(results_by_time)
             first_id = step > 1 ? 1 : meta.start_offset
             last_id =
                 step == meta.len ? meta.interval_len - meta.end_offset : meta.interval_len
-            if last_id - first_id > size(df, 1)
+            if last_id - first_id > size(array, 1)
                 error(
-                    "Variable $(encode_key_as_string(key)) has $(size(df, 1)) number of steps, that is different than the default problem horizon. \
+                    "Variable $(encode_key_as_string(key)) has $(size(array, 1)) number of steps, that is different than the default problem horizon. \
               Can't calculate the realized variables. Use `read_variables` instead and write your own concatenation",
                 )
             end
-            for colname in propertynames(df)
-                colname == :DateTime && continue
-                col = df[!, colname][first_id:last_id]
-                if !haskey(results_concat, colname)
-                    results_concat[colname] = col
-                else
-                    results_concat[colname] = vcat(results_concat[colname], col)
-                end
-            end
+            row_start = (step - 1) * meta.interval_len + 1
+            row_end = row_start + last_id - first_id
+            matrix[row_start:row_end, :] = array[first_id:last_id, :]
         end
-        realized_values[key] = DataFrames.DataFrame(results_concat; copycols = false)
+        df = DataFrames.DataFrame(matrix, collect(columns); copycols = false)
         DataFrames.insertcols!(
-            realized_values[key],
+            df,
             1,
             :DateTime => meta.realized_timestamps,
         )
+        lock(lk) do
+            realized_values[key] = df
+        end
     end
+
+    duration = time() - start
+    if Threads.nthreads() == 1 && duration > 10.0
+        @info "Time to read results: $duration seconds. You will likely get faster " *
+              "results by starting Julia with multiple threads."
+    end
+
     return realized_values
 end

--- a/src/simulation/simulation.jl
+++ b/src/simulation/simulation.jl
@@ -771,7 +771,7 @@ function _update_simulation_state!(sim::Simulation, model::DecisionModel)
     for field in fieldnames(DatasetContainer)
         for key in list_decision_model_keys(store, model_name, field)
             !has_dataset(get_decision_states(state), key) && continue
-            res = read_result(DataFrames.DataFrame, store, model_name, key, simulation_time)
+            res = read_result(DenseAxisArray, store, model_name, key, simulation_time)
             update_decision_state!(state, key, res, simulation_time, model_params)
         end
     end

--- a/src/simulation/simulation_results.jl
+++ b/src/simulation/simulation_results.jl
@@ -12,10 +12,6 @@ function check_folder_integrity(folder::String)
     return false
 end
 
-function _fill_result_value_container(fields)
-    return FieldResultsByTime(x => ResultsByTime() for x in fields)
-end
-
 struct SimulationResults
     path::String
     params::SimulationStoreParams

--- a/src/simulation/simulation_state.jl
+++ b/src/simulation/simulation_state.jl
@@ -88,7 +88,7 @@ function _initialize_model_states!(
             !should_write_resulting_value(key) && continue
             value_counts = params[key].horizon ÷ params[key].resolution
             column_names = get_column_names(key, value)
-            if !haskey(field_states, key) || length(field_states[key]) < value_counts
+            if !haskey(field_states, key) || get_num_rows(field_states[key]) < value_counts
                 field_states[key] = InMemoryDataset(
                     fill!(
                         DenseAxisArray{Float64}(undef, column_names, 1:value_counts),
@@ -222,7 +222,11 @@ function update_decision_state!(
     if simulation_time > get_end_of_step_timestamp(state_data)
         state_data_index = 1
         state_data.timestamps[:] .=
-            range(simulation_time; step = state_resolution, length = length(state_data))
+            range(
+                simulation_time;
+                step = state_resolution,
+                length = get_num_rows(state_data),
+            )
     else
         state_data_index = find_timestamp_index(state_timestamps, simulation_time)
     end
@@ -259,7 +263,11 @@ function update_decision_state!(
     if simulation_time > get_end_of_step_timestamp(state_data)
         state_data_index = 1
         state_data.timestamps[:] .=
-            range(simulation_time; step = state_resolution, length = length(state_data))
+            range(
+                simulation_time;
+                step = state_resolution,
+                length = get_num_rows(state_data),
+            )
     else
         state_data_index = find_timestamp_index(state_timestamps, simulation_time)
     end
@@ -296,7 +304,11 @@ function update_decision_state!(
     if simulation_time > get_end_of_step_timestamp(state_data)
         state_data_index = 1
         state_data.timestamps[:] .=
-            range(simulation_time; step = state_resolution, length = length(state_data))
+            range(
+                simulation_time;
+                step = state_resolution,
+                length = get_num_rows(state_data),
+            )
     else
         state_data_index = find_timestamp_index(state_data.timestamps, simulation_time)
     end
@@ -316,7 +328,7 @@ function update_decision_state!(
     column_names = axes(state_data.values)[1]
     for t in result_time_index
         state_range = state_data_index:(state_data_index + offset)
-        @assert_op state_range[end] <= length(state_data)
+        @assert_op state_range[end] <= get_num_rows(state_data)
         for name in column_names, i in state_range
             if t == 1 && i == 1
                 state_data.values[name, i] = store_data[name, t] * resolution_ratio

--- a/src/simulation/simulation_state.jl
+++ b/src/simulation/simulation_state.jl
@@ -1,16 +1,16 @@
 struct SimulationState
     current_time::Base.RefValue{Dates.DateTime}
     last_decision_model::Base.RefValue{Symbol}
-    decision_states::DatasetContainer{DataFrameDataset}
-    system_states::DatasetContainer{DataFrameDataset}
+    decision_states::DatasetContainer{InMemoryDataset}
+    system_states::DatasetContainer{InMemoryDataset}
 end
 
 function SimulationState()
     return SimulationState(
         Ref(UNSET_INI_TIME),
         Ref(:None),
-        DatasetContainer{DataFrameDataset}(),
-        DatasetContainer{DataFrameDataset}(),
+        DatasetContainer{InMemoryDataset}(),
+        DatasetContainer{InMemoryDataset}(),
     )
 end
 
@@ -89,10 +89,10 @@ function _initialize_model_states!(
             value_counts = params[key].horizon ÷ params[key].resolution
             column_names = get_column_names(key, value)
             if !haskey(field_states, key) || length(field_states[key]) < value_counts
-                field_states[key] = DataFrameDataset(
-                    DataFrames.DataFrame(
-                        fill(NaN, value_counts, length(column_names)),
-                        column_names,
+                field_states[key] = InMemoryDataset(
+                    fill!(
+                        DenseAxisArray{Float64}(undef, column_names, 1:value_counts),
+                        NaN,
                     ),
                     collect(
                         range(
@@ -125,7 +125,7 @@ function _initialize_system_states!(
             emulator_states,
             key,
             make_system_state(
-                DataFrames.DataFrame(cols .=> NaN),
+                fill!(DenseAxisArray{Float64}(undef, cols, 1:1), NaN),
                 simulation_initial_time,
                 min_res,
             ),
@@ -153,7 +153,7 @@ function _initialize_system_states!(
                 emulator_states,
                 key,
                 make_system_state(
-                    DataFrames.DataFrame(column_names .=> NaN),
+                    fill!(DenseAxisArray{Float64}(undef, column_names, 1:1), NaN),
                     simulation_initial_time,
                     get_resolution(emulation_model),
                 ),
@@ -173,7 +173,7 @@ function _initialize_system_states!(
             emulator_states,
             key,
             make_system_state(
-                DataFrames.DataFrame(cols .=> NaN),
+                fill!(DenseAxisArray{Float64}(undef, cols, 1:1), NaN),
                 simulation_initial_time,
                 get_resolution(emulation_model),
             ),
@@ -207,11 +207,12 @@ end
 function update_decision_state!(
     state::SimulationState,
     key::OptimizationContainerKey,
-    store_data::DataFrames.DataFrame,
+    store_data::DenseAxisArray{Float64},
     simulation_time::Dates.DateTime,
     model_params::ModelStoreParams,
 )
     state_data = get_decision_state_data(state, key)
+    column_names = get_column_names(state_data)
     model_resolution = get_resolution(model_params)
     state_resolution = get_data_resolution(state_data)
     resolution_ratio = model_resolution ÷ state_resolution
@@ -227,13 +228,13 @@ function update_decision_state!(
     end
 
     offset = resolution_ratio - 1
-    result_time_index = axes(store_data)[1]
+    result_time_index = axes(store_data)[2]
     set_update_timestamp!(state_data, simulation_time)
     for t in result_time_index
         state_range = state_data_index:(state_data_index + offset)
-        for name in DataFrames.names(store_data), i in state_range
+        for name in column_names, i in state_range
             # TODO: We could also interpolate here
-            state_data.values[i, name] = store_data[t, name]
+            state_data.values[name, i] = store_data[name, t]
         end
         set_last_recorded_row!(state_data, state_range[end])
         state_data_index += resolution_ratio
@@ -244,7 +245,7 @@ end
 function update_decision_state!(
     state::SimulationState,
     key::AuxVarKey{EnergyOutput, T},
-    store_data::DataFrames.DataFrame,
+    store_data::DenseAxisArray{Float64},
     simulation_time::Dates.DateTime,
     model_params::ModelStoreParams,
 ) where {T <: PSY.Component}
@@ -264,12 +265,13 @@ function update_decision_state!(
     end
 
     offset = resolution_ratio - 1
-    result_time_index = axes(store_data)[1]
+    result_time_index = axes(store_data)[2]
     set_update_timestamp!(state_data, simulation_time)
+    column_names = axes(state_data.values)[1]
     for t in result_time_index
         state_range = state_data_index:(state_data_index + offset)
-        for name in DataFrames.names(store_data), i in state_range
-            state_data.values[i, name] = store_data[t, name] / resolution_ratio
+        for name in column_names, i in state_range
+            state_data.values[name, i] = store_data[name, t] / resolution_ratio
         end
         set_last_recorded_row!(state_data, state_range[end])
         state_data_index += resolution_ratio
@@ -281,7 +283,7 @@ end
 function update_decision_state!(
     state::SimulationState,
     key::AuxVarKey{S, T},
-    store_data::DataFrames.DataFrame,
+    store_data::DenseAxisArray{Float64},
     simulation_time::Dates.DateTime,
     model_params::ModelStoreParams,
 ) where {T <: PSY.Component, S <: Union{TimeDurationOff, TimeDurationOn}}
@@ -300,7 +302,7 @@ function update_decision_state!(
     end
 
     offset = resolution_ratio - 1
-    result_time_index = axes(store_data)[1]
+    result_time_index = axes(store_data)[2]
     set_update_timestamp!(state_data, simulation_time)
 
     if resolution_ratio == 1.0
@@ -311,16 +313,17 @@ function update_decision_state!(
         error("Incorrect Problem Resolution specification")
     end
 
+    column_names = axes(state_data.values)[1]
     for t in result_time_index
         state_range = state_data_index:(state_data_index + offset)
         @assert_op state_range[end] <= length(state_data)
-        for name in DataFrames.names(store_data), i in state_range
+        for name in column_names, i in state_range
             if t == 1 && i == 1
-                state_data.values[i, name] = store_data[t, name] * resolution_ratio
+                state_data.values[name, i] = store_data[name, t] * resolution_ratio
             else
-                state_data.values[i, name] =
-                    if store_data[t, name] > 0
-                        state_data.values[i - 1, name] + increment_per_period
+                state_data.values[name, i] =
+                    if store_data[name, t] > 0
+                        state_data.values[name, i - 1] + increment_per_period
                     else
                         0
                     end
@@ -354,11 +357,11 @@ function get_system_state_data(state::SimulationState, key::OptimizationContaine
 end
 
 function get_system_state_value(state::SimulationState, key::OptimizationContainerKey)
-    return get_dataset_values(get_system_states(state), key)[1, :]
+    return get_dataset_values(get_system_states(state), key)[:, 1]
 end
 
 function update_system_state!(
-    state::DatasetContainer{DataFrameDataset},
+    state::DatasetContainer{InMemoryDataset},
     key::OptimizationContainerKey,
     store::SimulationStore,
     model_name::Symbol,
@@ -366,7 +369,7 @@ function update_system_state!(
 )
     em_data = get_em_data(store)
     ix = get_last_recorded_row(em_data, key)
-    res = read_result(DataFrames.DataFrame, store, model_name, key, ix)
+    res = read_result(DenseAxisArray, store, model_name, key, ix)
     dataset = get_dataset(state, key)
     set_update_timestamp!(dataset, simulation_time)
     set_dataset_values!(state, key, 1, res)
@@ -375,9 +378,9 @@ function update_system_state!(
 end
 
 function update_system_state!(
-    state::DatasetContainer{DataFrameDataset},
+    state::DatasetContainer{InMemoryDataset},
     key::OptimizationContainerKey,
-    decision_state::DatasetContainer{DataFrameDataset},
+    decision_state::DatasetContainer{InMemoryDataset},
     simulation_time::Dates.DateTime,
 )
     decision_dataset = get_dataset(decision_state, key)
@@ -409,9 +412,9 @@ function update_system_state!(
 end
 
 function update_system_state!(
-    state::DatasetContainer{DataFrameDataset},
+    state::DatasetContainer{InMemoryDataset},
     key::AuxVarKey{T, PSY.ThermalStandard},
-    decision_state::DatasetContainer{DataFrameDataset},
+    decision_state::DatasetContainer{InMemoryDataset},
     simulation_time::Dates.DateTime,
 ) where {T <: Union{TimeDurationOn, TimeDurationOff}}
     decision_dataset = get_dataset(decision_state, key)

--- a/src/utils/dataframes_utils.jl
+++ b/src/utils/dataframes_utils.jl
@@ -15,10 +15,6 @@ function to_dataframe(array::SparseAxisArray, key::OptimizationContainerKey)
     return DataFrames.DataFrame(to_matrix(array), get_column_names(key, array))
 end
 
-function to_dataframe(array::Matrix{Float64}, key::OptimizationContainerKey)
-    return DataFrames.DataFrame(array, get_column_names(key, array))
-end
-
 function to_matrix(df::DataFrames.DataFrame)
     return Matrix{Float64}(df)
 end

--- a/src/utils/dataframes_utils.jl
+++ b/src/utils/dataframes_utils.jl
@@ -7,20 +7,20 @@ Creates a DataFrame from a JuMP DenseAxisArray or SparseAxisArray.
   - `array`: JuMP DenseAxisArray or SparseAxisArray to convert
   - `key::OptimizationContainerKey`:
 """
-function axis_array_to_dataframe(array::DenseAxisArray, key::OptimizationContainerKey)
+function to_dataframe(array::DenseAxisArray, key::OptimizationContainerKey)
     return DataFrames.DataFrame(to_matrix(array), get_column_names(key, array))
 end
 
-function axis_array_to_dataframe(array::SparseAxisArray, key::OptimizationContainerKey)
+function to_dataframe(array::SparseAxisArray, key::OptimizationContainerKey)
     return DataFrames.DataFrame(to_matrix(array), get_column_names(key, array))
 end
 
-function axis_array_to_dataframe(array::Matrix{Float64}, key::OptimizationContainerKey)
+function to_dataframe(array::Matrix{Float64}, key::OptimizationContainerKey)
     return DataFrames.DataFrame(array, get_column_names(key, array))
 end
 
 function to_matrix(df::DataFrames.DataFrame)
-    return Matrix{Float64}(vals)
+    return Matrix{Float64}(df)
 end
 
 function to_matrix(df_row::DataFrames.DataFrameRow{DataFrames.DataFrame, DataFrames.Index})

--- a/test/test_simulation_build.jl
+++ b/test/test_simulation_build.jl
@@ -39,10 +39,10 @@
     ed_vars = [ActivePowerVariable]
     for (key, data) in state.decision_states.variables
         if PSI.get_entry_type(key) ∈ uc_vars
-            count, _ = size(data.values)
+            _, count = size(data.values)
             @test count == 24
         elseif PSI.get_entry_type(key) ∈ ed_vars
-            count, _ = size(data.values)
+            _, count = size(data.values)
             @test count == 288
         end
     end

--- a/test/test_simulation_results.jl
+++ b/test/test_simulation_results.jl
@@ -417,10 +417,16 @@ function test_decision_problem_results_values(
     )
 
     @test !isempty(
-        results_ed.values.variables[PSI.VariableKey(ActivePowerVariable, ThermalStandard)],
+        PSI.get_cached_variables(results_ed)[PSI.VariableKey(
+            ActivePowerVariable,
+            ThermalStandard,
+        )].data,
     )
     @test length(
-        results_ed.values.variables[PSI.VariableKey(ActivePowerVariable, ThermalStandard)],
+        PSI.get_cached_variables(results_ed)[PSI.VariableKey(
+            ActivePowerVariable,
+            ThermalStandard,
+        )].data,
     ) == 3
     @test length(results_ed) == 3
 
@@ -447,8 +453,9 @@ function test_decision_problem_results_values(
     )
 
     empty!(results_ed)
-    @test isempty(
-        results_ed.values.variables[PSI.VariableKey(ActivePowerVariable, ThermalStandard)],
+    @test !haskey(
+        PSI.get_cached_variables(results_ed),
+        PSI.VariableKey(ActivePowerVariable, ThermalStandard),
     )
 
     initial_time = DateTime("2024-01-01T00:00:00")
@@ -462,18 +469,24 @@ function test_decision_problem_results_values(
     )
 
     @test !isempty(
-        results_ed.values.variables[PSI.VariableKey(ActivePowerVariable, ThermalStandard)],
+        PSI.get_cached_variables(results_ed)[PSI.VariableKey(
+            ActivePowerVariable,
+            ThermalStandard,
+        )].data,
     )
     @test !isempty(
-        results_ed.values.duals[PSI.ConstraintKey(CopperPlateBalanceConstraint, System)],
+        PSI.get_cached_duals(results_ed)[PSI.ConstraintKey(
+            CopperPlateBalanceConstraint,
+            System,
+        )].data,
     )
     @test !isempty(
-        results_ed.values.parameters[PSI.ParameterKey{
+        PSI.get_cached_parameters(results_ed)[PSI.ParameterKey{
             ActivePowerTimeSeriesParameter,
             RenewableDispatch,
         }(
             "",
-        )],
+        )].data,
     )
 end
 

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -8,35 +8,35 @@ end
 end
 
 @testset "Axis Array to DataFrame" begin
-    # The axis_array_to_dataframe test the use of the `to_matrix` and `get_column_names` methods
+    # The to_dataframe test the use of the `to_matrix` and `get_column_names` methods
     one = PSI.DenseAxisArray{Float64}(undef, 1:2)
     fill!(one, 1.0)
     mock_key = PSI.VariableKey(ActivePowerVariable, ThermalStandard)
-    one_df = PSI.axis_array_to_dataframe(one, mock_key)
+    one_df = PSI.to_dataframe(one, mock_key)
     test_df = DataFrames.DataFrame(PSI.encode_key(mock_key) => [1.0, 1.0])
     @test one_df == test_df
 
     two = PSI.DenseAxisArray{Float64}(undef, [:a], 1:2)
     fill!(two, 1.0)
-    two_df = PSI.axis_array_to_dataframe(two, mock_key)
+    two_df = PSI.to_dataframe(two, mock_key)
     test_df = DataFrames.DataFrame(:a => [1.0, 1.0])
     @test two_df == test_df
 
     three = PSI.DenseAxisArray{Float64}(undef, [:a], 1:2, 1:3)
-    @test_throws ErrorException PSI.axis_array_to_dataframe(three, mock_key)
+    @test_throws ErrorException PSI.to_dataframe(three, mock_key)
 
     four = PSI.DenseAxisArray{Float64}(undef, [:a], 1:2, 1:3, 1:5)
-    @test_throws ErrorException PSI.axis_array_to_dataframe(four, mock_key)
+    @test_throws ErrorException PSI.to_dataframe(four, mock_key)
 
     sparse_num =
         JuMP.Containers.@container([i = 1:10, j = (i + 1):10, t = 1:24], 0.0 + i + j + t)
-    @test_throws MethodError PSI.axis_array_to_dataframe(sparse_num, mock_key)
+    @test_throws MethodError PSI.to_dataframe(sparse_num, mock_key)
 
     i_num = 1:10
     j_vals = Dict("$i" => string.((i + 1):11) for i in i_num)
     sparse_valid =
         JuMP.Containers.@container([i = string.(i_num), j = j_vals[i], t = 1:24], rand())
-    df = PSI.axis_array_to_dataframe(sparse_valid, mock_key)
+    df = PSI.to_dataframe(sparse_valid, mock_key)
     @test size(df) == (24, 55)
 end
 


### PR DESCRIPTION
This PR refactors the storage and access of results in order to improve performance. DataFrames are replaced by DenseAxisArrays. It also optimizes the generation of realized results.

Removed a lot of duplication in these methods and underlying code. Callers should now use `read_results_with_keys` instead.
```
read_aux_variables_with_keys
read_duals_with_keys
read_expressions_with_keys
read_parameters_with_keys
read_variables_with_keys
```