### PR TITLE
Fix bug in custom indexing for realized results

### DIFF
--- a/src/simulation/realized_meta.jl
+++ b/src/simulation/realized_meta.jl
@@ -59,6 +59,7 @@ function get_realization(
         columns = get_column_names(results_by_time)
         num_cols = length(columns)
         matrix = Matrix{Float64}(undef, num_rows, num_cols)
+        row_index = 1
         for (step, (_, array)) in enumerate(results_by_time)
             first_id = step > 1 ? 1 : meta.start_offset
             last_id =
@@ -69,9 +70,9 @@ function get_realization(
               Can't calculate the realized variables. Use `read_variables` instead and write your own concatenation",
                 )
             end
-            row_start = (step - 1) * meta.interval_len + 1
-            row_end = row_start + last_id - first_id
-            matrix[row_start:row_end, :] = array[first_id:last_id, :]
+            row_end = row_index + last_id - first_id
+            matrix[row_index:row_end, :] = array[first_id:last_id, :]
+            row_index += last_id - first_id + 1
         end
         df = DataFrames.DataFrame(matrix, collect(columns); copycols = false)
         DataFrames.insertcols!(

--- a/test/test_simulation_results.jl
+++ b/test/test_simulation_results.jl
@@ -311,6 +311,17 @@ function test_decision_problem_results_values(
         @test size(var)[1] == 48
     end
 
+    # Test custom indexing.
+    realized_variable_uc2 =
+        read_realized_variables(
+            results_uc,
+            [(ActivePowerVariable, ThermalStandard)];
+            start_time = Dates.DateTime("2024-01-01T01:00:00"),
+            len = 47,
+        )
+    @test realized_variable_uc["ActivePowerVariable__ThermalStandard"][2:end, :] ==
+          realized_variable_uc2["ActivePowerVariable__ThermalStandard"]
+
     realized_param_uc = read_realized_parameters(results_uc)
     @test length(keys(realized_param_uc)) == 3
     for param in values(realized_param_uc)


### PR DESCRIPTION
This bug was introduced in commit
21f6dff464b322f4785a426ef6dd215082ed0510. Passing custom values of start_time and len that cause the code to span arrays from two initial times caused an array indexing error.