### PR TITLE
2 reference bus systems.

### DIFF
--- a/src/core/network_model.jl
+++ b/src/core/network_model.jl
@@ -69,12 +69,6 @@ function instantiate_network_model(
     if isempty(model.subnetworks)
         model.subnetworks = PNM.find_subnetworks(sys)
     end
-
-    if length(model.subnetworks) > 1
-        error(
-            "System Contains Multiple Subnetworks. This is not compatible with network model $T",
-        )
-    end
     return
 end
 


### PR DESCRIPTION
The code was updated by removing the error thrown in case of presence of two reference buses.

Tests were executed and the different methods passed, except for two. 

NOTE: the following models were not successful for the following reasons.
- SOCWRConicPowerModel -> unable to find a proper solver to test
- DCPLLPowerModel -> tests on sub-system balance fail