### PR TITLE
Replace parameterized type variables

### DIFF
--- a/src/devices_models/device_constructors/branch_constructor.jl
+++ b/src/devices_models/device_constructors/branch_constructor.jl
@@ -106,7 +106,7 @@ function construct_device!(
             container,
             devices,
             device_model,
-            typeof(network_model).parameters[1],
+            get_network_formulation(network_model),
         )
     end
     return

--- a/src/devices_models/device_constructors/branch_constructor.jl
+++ b/src/devices_models/device_constructors/branch_constructor.jl
@@ -173,9 +173,10 @@ function construct_device!(
     ::OptimizationContainer,
     ::PSY.System,
     ::ArgumentConstructStage,
-    ::DeviceModel{T, StaticBranch},
-    ::NetworkModel{S},
-) where {T <: PSY.ACBranch, S <: PM.AbstractActivePowerModel} end
+    ::DeviceModel{<: PSY.ACBranch, StaticBranch},
+    ::NetworkModel{<: PM.AbstractActivePowerModel},
+)
+end
 
 # For DC Power only. Implements constraints
 function construct_device!(
@@ -303,8 +304,8 @@ function construct_device!(
     ::PSY.System,
     ::ArgumentConstructStage,
     ::DeviceModel{T, StaticBranch},
-    ::NetworkModel{S},
-) where {T <: PSY.ACBranch, S <: PM.AbstractPowerModel} end
+    ::NetworkModel{<: PM.AbstractPowerModel},
+) where {T <: PSY.ACBranch} end
 
 function construct_device!(
     container::OptimizationContainer,
@@ -328,8 +329,8 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     ::DeviceModel{T, StaticBranchBounds},
-    ::NetworkModel{S},
-) where {T <: PSY.ACBranch, S <: PM.AbstractPowerModel} end
+    ::NetworkModel{<: PM.AbstractPowerModel},
+) where {T <: PSY.ACBranch} end
 
 function construct_device!(
     container::OptimizationContainer,
@@ -401,13 +402,9 @@ function construct_device!(
     ::OptimizationContainer,
     ::PSY.System,
     ::ArgumentConstructStage,
-    ::DeviceModel{T, F},
-    ::NetworkModel{S},
-) where {
-    T <: TwoTerminalHVDCTypes,
-    F <: HVDCTwoTerminalUnbounded,
-    S <: PM.AbstractPowerModel,
-}
+    ::DeviceModel{<: TwoTerminalHVDCTypes, <: HVDCTwoTerminalUnbounded},
+    ::NetworkModel{<: PM.AbstractPowerModel},
+)
     return
 end
 
@@ -415,13 +412,9 @@ function construct_device!(
     container::OptimizationContainer,
     sys::PSY.System,
     ::ModelConstructStage,
-    model::DeviceModel{T, U},
-    ::NetworkModel{S},
-) where {
-    T <: TwoTerminalHVDCTypes,
-    U <: HVDCTwoTerminalUnbounded,
-    S <: PM.AbstractPowerModel,
-}
+    model::DeviceModel{<: TwoTerminalHVDCTypes, <: HVDCTwoTerminalUnbounded},
+    ::NetworkModel{<: PM.AbstractPowerModel},
+)
     add_constraint_dual!(container, sys, model)
 end
 
@@ -431,11 +424,10 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{T, U},
-    network_model::NetworkModel{S},
+    network_model::NetworkModel{<: Union{StandardPTDFModel, PTDFPowerModel}},
 ) where {
     T <: TwoTerminalHVDCTypes,
     U <: HVDCTwoTerminalUnbounded,
-    S <: Union{StandardPTDFModel, PTDFPowerModel},
 }
     devices =
         get_available_components(T, sys, get_attribute(model, "filter_function"))
@@ -456,13 +448,9 @@ function construct_device!(
     container::OptimizationContainer,
     sys::PSY.System,
     ::ModelConstructStage,
-    model::DeviceModel{T, U},
-    network_model::NetworkModel{S},
-) where {
-    T <: TwoTerminalHVDCTypes,
-    U <: HVDCTwoTerminalUnbounded,
-    S <: Union{StandardPTDFModel, PTDFPowerModel},
-}
+    model::DeviceModel{<: TwoTerminalHVDCTypes, <: HVDCTwoTerminalUnbounded},
+    network_model::NetworkModel{<: Union{StandardPTDFModel, PTDFPowerModel}},
+)
     add_constraint_dual!(container, sys, model)
     return
 end
@@ -471,13 +459,9 @@ function construct_device!(
     ::OptimizationContainer,
     ::PSY.System,
     ::ArgumentConstructStage,
-    ::DeviceModel{T, F},
-    ::NetworkModel{S},
-) where {
-    T <: TwoTerminalHVDCTypes,
-    F <: HVDCTwoTerminalLossless,
-    S <: PM.AbstractPowerModel,
-}
+    ::DeviceModel{<: TwoTerminalHVDCTypes, <: HVDCTwoTerminalLossless},
+    ::NetworkModel{<: PM.AbstractPowerModel}
+)
     return
 end
 
@@ -485,13 +469,9 @@ function construct_device!(
     container::OptimizationContainer,
     sys::PSY.System,
     ::ModelConstructStage,
-    model::DeviceModel{T, U},
-    network_model::NetworkModel{S},
-) where {
-    T <: TwoTerminalHVDCTypes,
-    U <: HVDCTwoTerminalLossless,
-    S <: PM.AbstractPowerModel,
-}
+    model::DeviceModel{T, <: HVDCTwoTerminalLossless},
+    network_model::NetworkModel{<: PM.AbstractPowerModel},
+) where {T <: TwoTerminalHVDCTypes}
     devices =
         get_available_components(T, sys, get_attribute(model, "filter_function"))
     add_constraints!(container, FlowRateConstraint, devices, model, network_model)
@@ -610,8 +590,8 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{T, HVDCTwoTerminalDispatch},
-    network_model::NetworkModel{U},
-) where {T <: TwoTerminalHVDCTypes, U <: PM.AbstractActivePowerModel}
+    network_model::NetworkModel{<: PM.AbstractActivePowerModel},
+) where {T <: TwoTerminalHVDCTypes}
     devices =
         get_available_components(T, sys, get_attribute(model, "filter_function"))
     add_variables!(
@@ -667,8 +647,8 @@ function construct_device!(
     sys::PSY.System,
     ::ModelConstructStage,
     model::DeviceModel{T, HVDCTwoTerminalDispatch},
-    network_model::NetworkModel{U},
-) where {T <: TwoTerminalHVDCTypes, U <: PM.AbstractActivePowerModel}
+    network_model::NetworkModel{<: PM.AbstractActivePowerModel},
+) where {T <: TwoTerminalHVDCTypes}
     devices =
         get_available_components(T, sys, get_attribute(model, "filter_function"))
     add_constraints!(container, FlowRateConstraintFromTo, devices, model, network_model)

--- a/src/devices_models/device_constructors/branch_constructor.jl
+++ b/src/devices_models/device_constructors/branch_constructor.jl
@@ -412,9 +412,9 @@ function construct_device!(
     ::OptimizationContainer,
     ::PSY.System,
     ::ArgumentConstructStage,
-    ::DeviceModel{<:TwoTerminalHVDCTypes, HVDCTwoTerminalUnbounded},
+    ::DeviceModel{T, HVDCTwoTerminalUnbounded},
     ::NetworkModel{<:PM.AbstractPowerModel},
-)
+) where {T <: TwoTerminalHVDCTypes}
     return
 end
 
@@ -433,15 +433,12 @@ function construct_device!(
     container::OptimizationContainer,
     sys::PSY.System,
     ::ArgumentConstructStage,
-    model::DeviceModel{T, U},
+    model::DeviceModel{T, HVDCTwoTerminalUnbounded},
     network_model::NetworkModel{<:Union{StandardPTDFModel, PTDFPowerModel}},
-) where {
-    T <: TwoTerminalHVDCTypes,
-    U <: HVDCTwoTerminalUnbounded,
-}
+) where {T <: TwoTerminalHVDCTypes}
     devices =
         get_available_components(T, sys, get_attribute(model, "filter_function"))
-    add_variables!(container, FlowActivePowerVariable, devices, U())
+    add_variables!(container, FlowActivePowerVariable, devices, HVDCTwoTerminalUnbounded())
     add_to_expression!(
         container,
         ActivePowerBalance,
@@ -458,7 +455,7 @@ function construct_device!(
     container::OptimizationContainer,
     sys::PSY.System,
     ::ModelConstructStage,
-    model::DeviceModel{<:TwoTerminalHVDCTypes, <:HVDCTwoTerminalUnbounded},
+    model::DeviceModel{<:TwoTerminalHVDCTypes, HVDCTwoTerminalUnbounded},
     network_model::NetworkModel{<:Union{StandardPTDFModel, PTDFPowerModel}},
 )
     add_constraint_dual!(container, sys, model)
@@ -469,9 +466,9 @@ function construct_device!(
     ::OptimizationContainer,
     ::PSY.System,
     ::ArgumentConstructStage,
-    ::DeviceModel{<:TwoTerminalHVDCTypes, HVDCTwoTerminalLossless},
+    ::DeviceModel{T, HVDCTwoTerminalLossless},
     ::NetworkModel{<:PM.AbstractPowerModel},
-)
+) where {T <: TwoTerminalHVDCTypes}
     return
 end
 
@@ -494,12 +491,12 @@ function construct_device!(
     container::OptimizationContainer,
     sys::PSY.System,
     ::ArgumentConstructStage,
-    model::DeviceModel{T, U},
+    model::DeviceModel{T, HVDCTwoTerminalLossless},
     network_model::NetworkModel{<:Union{StandardPTDFModel, PTDFPowerModel}},
-) where {T <: TwoTerminalHVDCTypes, U <: HVDCTwoTerminalLossless}
+) where {T <: TwoTerminalHVDCTypes}
     devices =
         get_available_components(T, sys, get_attribute(model, "filter_function"))
-    add_variables!(container, FlowActivePowerVariable, devices, U())
+    add_variables!(container, FlowActivePowerVariable, devices, HVDCTwoTerminalLossless())
     add_to_expression!(
         container,
         ActivePowerBalance,

--- a/src/devices_models/device_constructors/constructor_validations.jl
+++ b/src/devices_models/device_constructors/constructor_validations.jl
@@ -1,7 +1,7 @@
 function validate_available_devices(
-    device_model::DeviceModel{T, U},
+    device_model::DeviceModel{T, <: AbstractDeviceFormulation},
     system::PSY.System,
-) where {T <: PSY.Device, U <: AbstractDeviceFormulation}
+) where {T <: PSY.Device}
     devices =
         get_available_components(T, system, get_attribute(device_model, "filter_function"))
     if isempty(devices)

--- a/src/devices_models/device_constructors/constructor_validations.jl
+++ b/src/devices_models/device_constructors/constructor_validations.jl
@@ -1,5 +1,5 @@
 function validate_available_devices(
-    device_model::DeviceModel{T, <: AbstractDeviceFormulation},
+    device_model::DeviceModel{T, <:AbstractDeviceFormulation},
     system::PSY.System,
 ) where {T <: PSY.Device}
     devices =

--- a/src/devices_models/device_constructors/hvdcsystems_constructor.jl
+++ b/src/devices_models/device_constructors/hvdcsystems_constructor.jl
@@ -3,7 +3,7 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{PSY.InterconnectingConverter, LossLessConverter},
-    network_model::NetworkModel{<: PM.AbstractActivePowerModel},
+    network_model::NetworkModel{<:PM.AbstractActivePowerModel},
 )
     devices = get_available_components(PSY.InterconnectingConverter, sys)
     add_variables!(container, ActivePowerVariable, devices, LossLessConverter())
@@ -24,11 +24,11 @@ function construct_device!(
     sys::PSY.System,
     ::ModelConstructStage,
     model::DeviceModel{PSY.InterconnectingConverter, LossLessConverter},
-    ::NetworkModel{S},
-) where {S <: PM.AbstractActivePowerModel}
+    network_model::NetworkModel{<:PM.AbstractActivePowerModel},
+)
     devices = get_available_components(PSY.InterconnectingConverter, sys)
     add_feedforward_constraints!(container, model, devices)
-    objective_function!(container, devices, model, S)
+    objective_function!(container, devices, model, get_network_formulation(network_model))
     add_constraint_dual!(container, sys, model)
     return
 end
@@ -38,7 +38,7 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{PSY.TModelHVDCLine, LossLessLine},
-    network_model::NetworkModel{<: PM.AbstractActivePowerModel},
+    network_model::NetworkModel{<:PM.AbstractActivePowerModel},
 )
     devices = get_available_components(PSY.TModelHVDCLine, sys)
     add_variables!(container, FlowActivePowerVariable, devices, LossLessLine())
@@ -59,6 +59,6 @@ function construct_device!(
     sys::PSY.System,
     ::ModelConstructStage,
     model::DeviceModel{PSY.TModelHVDCLine, LossLessLine},
-    ::NetworkModel{<: PM.AbstractActivePowerModel},
+    ::NetworkModel{<:PM.AbstractActivePowerModel},
 )
 end

--- a/src/devices_models/device_constructors/hvdcsystems_constructor.jl
+++ b/src/devices_models/device_constructors/hvdcsystems_constructor.jl
@@ -3,8 +3,8 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{PSY.InterconnectingConverter, LossLessConverter},
-    network_model::NetworkModel{S},
-) where {S <: PM.AbstractActivePowerModel}
+    network_model::NetworkModel{<: PM.AbstractActivePowerModel},
+)
     devices = get_available_components(PSY.InterconnectingConverter, sys)
     add_variables!(container, ActivePowerVariable, devices, LossLessConverter())
     add_to_expression!(
@@ -38,8 +38,8 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{PSY.TModelHVDCLine, LossLessLine},
-    network_model::NetworkModel{S},
-) where {S <: PM.AbstractActivePowerModel}
+    network_model::NetworkModel{<: PM.AbstractActivePowerModel},
+)
     devices = get_available_components(PSY.TModelHVDCLine, sys)
     add_variables!(container, FlowActivePowerVariable, devices, LossLessLine())
     add_to_expression!(
@@ -59,8 +59,6 @@ function construct_device!(
     sys::PSY.System,
     ::ModelConstructStage,
     model::DeviceModel{PSY.TModelHVDCLine, LossLessLine},
-    ::NetworkModel{S},
-) where {S <: PM.AbstractActivePowerModel}
-    devices = get_available_components(PSY.TModelHVDCLine, sys)
-    return
+    ::NetworkModel{<: PM.AbstractActivePowerModel},
+)
 end

--- a/src/devices_models/device_constructors/load_constructor.jl
+++ b/src/devices_models/device_constructors/load_constructor.jl
@@ -3,7 +3,7 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{L, D},
-    network_model::NetworkModel{<: PM.AbstractPowerModel},
+    network_model::NetworkModel{<:PM.AbstractPowerModel},
 ) where {
     L <: PSY.ControllableLoad,
     D <: AbstractControllablePowerLoadFormulation,
@@ -43,13 +43,9 @@ function construct_device!(
     container::OptimizationContainer,
     sys::PSY.System,
     ::ModelConstructStage,
-    model::DeviceModel{L, D},
-    network_model::NetworkModel{S},
-) where {
-    L <: PSY.ControllableLoad,
-    D <: AbstractControllablePowerLoadFormulation,
-    S <: PM.AbstractPowerModel,
-}
+    model::DeviceModel{L, <:AbstractControllablePowerLoadFormulation},
+    network_model::NetworkModel{<:PM.AbstractPowerModel},
+) where {L <: PSY.ControllableLoad}
     devices =
         get_available_components(L, sys, get_attribute(model, "filter_function"))
 
@@ -71,7 +67,7 @@ function construct_device!(
     )
     add_feedforward_constraints!(container, model, devices)
 
-    objective_function!(container, devices, model, S)
+    objective_function!(container, devices, model, typeof(network_model).parameters[1])
 
     add_constraint_dual!(container, sys, model)
     return
@@ -82,7 +78,7 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{L, D},
-    network_model::NetworkModel{<: PM.AbstractActivePowerModel},
+    network_model::NetworkModel{<:PM.AbstractActivePowerModel},
 ) where {
     L <: PSY.ControllableLoad,
     D <: AbstractControllablePowerLoadFormulation,
@@ -112,13 +108,9 @@ function construct_device!(
     container::OptimizationContainer,
     sys::PSY.System,
     ::ModelConstructStage,
-    model::DeviceModel{L, D},
-    network_model::NetworkModel{S},
-) where {
-    L <: PSY.ControllableLoad,
-    D <: AbstractControllablePowerLoadFormulation,
-    S <: PM.AbstractActivePowerModel,
-}
+    model::DeviceModel{L, <:AbstractControllablePowerLoadFormulation},
+    network_model::NetworkModel{<:PM.AbstractActivePowerModel},
+) where {L <: PSY.ControllableLoad}
     devices =
         get_available_components(L, sys, get_attribute(model, "filter_function"))
 
@@ -132,7 +124,7 @@ function construct_device!(
     )
     add_feedforward_constraints!(container, model, devices)
 
-    objective_function!(container, devices, model, S)
+    objective_function!(container, devices, model, typeof(network_model).parameters[1])
 
     add_constraint_dual!(container, sys, model)
     return
@@ -143,7 +135,7 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{L, PowerLoadInterruption},
-    network_model::NetworkModel{<: PM.AbstractPowerModel},
+    network_model::NetworkModel{<:PM.AbstractPowerModel},
 ) where {L <: PSY.ControllableLoad}
     devices =
         get_available_components(L, sys, get_attribute(model, "filter_function"))
@@ -182,8 +174,8 @@ function construct_device!(
     sys::PSY.System,
     ::ModelConstructStage,
     model::DeviceModel{L, PowerLoadInterruption},
-    network_model::NetworkModel{S},
-) where {L <: PSY.ControllableLoad, S <: PM.AbstractPowerModel}
+    network_model::NetworkModel{<:PM.AbstractPowerModel},
+) where {L <: PSY.ControllableLoad}
     devices =
         get_available_components(L, sys, get_attribute(model, "filter_function"))
 
@@ -205,7 +197,7 @@ function construct_device!(
     )
     add_feedforward_constraints!(container, model, devices)
 
-    objective_function!(container, devices, model, S)
+    objective_function!(container, devices, model, typeof(network_model).parameters[1])
 
     add_constraint_dual!(container, sys, model)
     return
@@ -216,7 +208,7 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{L, PowerLoadInterruption},
-    network_model::NetworkModel{<: PM.AbstractActivePowerModel},
+    network_model::NetworkModel{<:PM.AbstractActivePowerModel},
 ) where {L <: PSY.ControllableLoad}
     devices =
         get_available_components(L, sys, get_attribute(model, "filter_function"))
@@ -245,8 +237,8 @@ function construct_device!(
     sys::PSY.System,
     ::ModelConstructStage,
     model::DeviceModel{L, PowerLoadInterruption},
-    network_model::NetworkModel{S},
-) where {L <: PSY.ControllableLoad, S <: PM.AbstractActivePowerModel}
+    network_model::NetworkModel{<:PM.AbstractActivePowerModel},
+) where {L <: PSY.ControllableLoad}
     devices =
         get_available_components(L, sys, get_attribute(model, "filter_function"))
 
@@ -260,7 +252,7 @@ function construct_device!(
     )
     add_feedforward_constraints!(container, model, devices)
 
-    objective_function!(container, devices, model, S)
+    objective_function!(container, devices, model, typeof(network_model).parameters[1])
 
     add_constraint_dual!(container, sys, model)
     return
@@ -271,7 +263,7 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{L, StaticPowerLoad},
-    network_model::NetworkModel{<: PM.AbstractPowerModel},
+    network_model::NetworkModel{<:PM.AbstractPowerModel},
 ) where {L <: PSY.ElectricLoad}
     devices =
         get_available_components(L, sys, get_attribute(model, "filter_function"))
@@ -303,7 +295,7 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{L, StaticPowerLoad},
-    network_model::NetworkModel{<: PM.AbstractActivePowerModel},
+    network_model::NetworkModel{<:PM.AbstractActivePowerModel},
 ) where {L <: PSY.ElectricLoad}
     devices =
         get_available_components(L, sys, get_attribute(model, "filter_function"))
@@ -325,8 +317,8 @@ function construct_device!(
     container::OptimizationContainer,
     sys::PSY.System,
     ::ModelConstructStage,
-    model::DeviceModel{<: PSY.ElectricLoad, StaticPowerLoad},
-    network_model::NetworkModel{<: PM.AbstractPowerModel},
+    model::DeviceModel{<:PSY.ElectricLoad, StaticPowerLoad},
+    network_model::NetworkModel{<:PM.AbstractPowerModel},
 )
     # Static PowerLoad doesn't add any constraints to the model. This function covers
     # AbstractPowerModel and AbtractActivePowerModel
@@ -337,8 +329,8 @@ function construct_device!(
     container::OptimizationContainer,
     sys::PSY.System,
     ::ArgumentConstructStage,
-    model::DeviceModel{L, <: AbstractControllablePowerLoadFormulation},
-    network_model::NetworkModel{<: PM.AbstractPowerModel},
+    model::DeviceModel{L, <:AbstractControllablePowerLoadFormulation},
+    network_model::NetworkModel{<:PM.AbstractPowerModel},
 ) where {L <: PSY.StaticLoad}
     devices =
         get_available_components(L, sys, get_attribute(model, "filter_function"))
@@ -369,8 +361,8 @@ function construct_device!(
     container::OptimizationContainer,
     sys::PSY.System,
     ::ArgumentConstructStage,
-    model::DeviceModel{L, <: AbstractControllablePowerLoadFormulation},
-    network_model::NetworkModel{<: PM.AbstractActivePowerModel},
+    model::DeviceModel{L, <:AbstractControllablePowerLoadFormulation},
+    network_model::NetworkModel{<:PM.AbstractActivePowerModel},
 ) where {L <: PSY.StaticLoad}
     devices =
         get_available_components(L, sys, get_attribute(model, "filter_function"))
@@ -392,7 +384,7 @@ function construct_device!(
     sys::PSY.System,
     ccs::ModelConstructStage,
     model::DeviceModel{L, D},
-    network_model::NetworkModel{<: PM.AbstractPowerModel},
+    network_model::NetworkModel{<:PM.AbstractPowerModel},
 ) where {
     L <: PSY.StaticLoad,
     D <: AbstractControllablePowerLoadFormulation,

--- a/src/devices_models/device_constructors/load_constructor.jl
+++ b/src/devices_models/device_constructors/load_constructor.jl
@@ -67,7 +67,7 @@ function construct_device!(
     )
     add_feedforward_constraints!(container, model, devices)
 
-    objective_function!(container, devices, model, typeof(network_model).parameters[1])
+    objective_function!(container, devices, model, get_network_formulation(network_model))
 
     add_constraint_dual!(container, sys, model)
     return
@@ -124,7 +124,7 @@ function construct_device!(
     )
     add_feedforward_constraints!(container, model, devices)
 
-    objective_function!(container, devices, model, typeof(network_model).parameters[1])
+    objective_function!(container, devices, model, get_network_formulation(network_model))
 
     add_constraint_dual!(container, sys, model)
     return
@@ -197,7 +197,7 @@ function construct_device!(
     )
     add_feedforward_constraints!(container, model, devices)
 
-    objective_function!(container, devices, model, typeof(network_model).parameters[1])
+    objective_function!(container, devices, model, get_network_formulation(network_model))
 
     add_constraint_dual!(container, sys, model)
     return
@@ -252,7 +252,7 @@ function construct_device!(
     )
     add_feedforward_constraints!(container, model, devices)
 
-    objective_function!(container, devices, model, typeof(network_model).parameters[1])
+    objective_function!(container, devices, model, get_network_formulation(network_model))
 
     add_constraint_dual!(container, sys, model)
     return

--- a/src/devices_models/device_constructors/load_constructor.jl
+++ b/src/devices_models/device_constructors/load_constructor.jl
@@ -3,11 +3,10 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{L, D},
-    network_model::NetworkModel{S},
+    network_model::NetworkModel{<: PM.AbstractPowerModel},
 ) where {
     L <: PSY.ControllableLoad,
     D <: AbstractControllablePowerLoadFormulation,
-    S <: PM.AbstractPowerModel,
 }
     devices =
         get_available_components(L, sys, get_attribute(model, "filter_function"))
@@ -83,11 +82,10 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{L, D},
-    network_model::NetworkModel{S},
+    network_model::NetworkModel{<: PM.AbstractActivePowerModel},
 ) where {
     L <: PSY.ControllableLoad,
     D <: AbstractControllablePowerLoadFormulation,
-    S <: PM.AbstractActivePowerModel,
 }
     devices =
         get_available_components(L, sys, get_attribute(model, "filter_function"))
@@ -145,8 +143,8 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{L, PowerLoadInterruption},
-    network_model::NetworkModel{S},
-) where {L <: PSY.ControllableLoad, S <: PM.AbstractPowerModel}
+    network_model::NetworkModel{<: PM.AbstractPowerModel},
+) where {L <: PSY.ControllableLoad}
     devices =
         get_available_components(L, sys, get_attribute(model, "filter_function"))
 
@@ -218,8 +216,8 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{L, PowerLoadInterruption},
-    network_model::NetworkModel{S},
-) where {L <: PSY.ControllableLoad, S <: PM.AbstractActivePowerModel}
+    network_model::NetworkModel{<: PM.AbstractActivePowerModel},
+) where {L <: PSY.ControllableLoad}
     devices =
         get_available_components(L, sys, get_attribute(model, "filter_function"))
 
@@ -273,8 +271,8 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{L, StaticPowerLoad},
-    network_model::NetworkModel{S},
-) where {L <: PSY.ElectricLoad, S <: PM.AbstractPowerModel}
+    network_model::NetworkModel{<: PM.AbstractPowerModel},
+) where {L <: PSY.ElectricLoad}
     devices =
         get_available_components(L, sys, get_attribute(model, "filter_function"))
 
@@ -305,8 +303,8 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{L, StaticPowerLoad},
-    network_model::NetworkModel{S},
-) where {L <: PSY.ElectricLoad, S <: PM.AbstractActivePowerModel}
+    network_model::NetworkModel{<: PM.AbstractActivePowerModel},
+) where {L <: PSY.ElectricLoad}
     devices =
         get_available_components(L, sys, get_attribute(model, "filter_function"))
 
@@ -327,9 +325,9 @@ function construct_device!(
     container::OptimizationContainer,
     sys::PSY.System,
     ::ModelConstructStage,
-    model::DeviceModel{L, StaticPowerLoad},
-    network_model::NetworkModel{S},
-) where {L <: PSY.ElectricLoad, S <: PM.AbstractPowerModel}
+    model::DeviceModel{<: PSY.ElectricLoad, StaticPowerLoad},
+    network_model::NetworkModel{<: PM.AbstractPowerModel},
+)
     # Static PowerLoad doesn't add any constraints to the model. This function covers
     # AbstractPowerModel and AbtractActivePowerModel
     return
@@ -339,13 +337,9 @@ function construct_device!(
     container::OptimizationContainer,
     sys::PSY.System,
     ::ArgumentConstructStage,
-    model::DeviceModel{L, D},
-    network_model::NetworkModel{S},
-) where {
-    L <: PSY.StaticLoad,
-    D <: AbstractControllablePowerLoadFormulation,
-    S <: PM.AbstractPowerModel,
-}
+    model::DeviceModel{L, <: AbstractControllablePowerLoadFormulation},
+    network_model::NetworkModel{<: PM.AbstractPowerModel},
+) where {L <: PSY.StaticLoad}
     devices =
         get_available_components(L, sys, get_attribute(model, "filter_function"))
 
@@ -375,13 +369,9 @@ function construct_device!(
     container::OptimizationContainer,
     sys::PSY.System,
     ::ArgumentConstructStage,
-    model::DeviceModel{L, D},
-    network_model::NetworkModel{S},
-) where {
-    L <: PSY.StaticLoad,
-    D <: AbstractControllablePowerLoadFormulation,
-    S <: PM.AbstractActivePowerModel,
-}
+    model::DeviceModel{L, <: AbstractControllablePowerLoadFormulation},
+    network_model::NetworkModel{<: PM.AbstractActivePowerModel},
+) where {L <: PSY.StaticLoad}
     devices =
         get_available_components(L, sys, get_attribute(model, "filter_function"))
 
@@ -402,11 +392,10 @@ function construct_device!(
     sys::PSY.System,
     ccs::ModelConstructStage,
     model::DeviceModel{L, D},
-    network_model::NetworkModel{S},
+    network_model::NetworkModel{<: PM.AbstractPowerModel},
 ) where {
     L <: PSY.StaticLoad,
     D <: AbstractControllablePowerLoadFormulation,
-    S <: PM.AbstractPowerModel,
 }
     if D != StaticPowerLoad
         @warn(

--- a/src/devices_models/device_constructors/regulationdevice_constructor.jl
+++ b/src/devices_models/device_constructors/regulationdevice_constructor.jl
@@ -98,7 +98,7 @@ function construct_device!(
         network_model,
     )
 
-    add_constraints!(container, ParticipationAssignmentConstraint, devices, model, S)
+    add_constraints!(container, ParticipationAssignmentConstraint, devices, model, AreaBalancePowerModel)
     objective_function!(container, devices, model)
     return
 end
@@ -107,9 +107,9 @@ function construct_device!(
     container::OptimizationContainer,
     sys::PSY.System,
     ::ArgumentConstructStage,
-    model::DeviceModel{PSY.RegulationDevice{T}, FixedOutput},
+    model::DeviceModel{PSY.RegulationDevice{<: PSY.StaticInjection}, FixedOutput},
     network_model::NetworkModel{AreaBalancePowerModel},
-) where {T <: PSY.StaticInjection}
+)
     devices = get_available_components(get_component_type(model), sys)
     add_parameters!(container, ActivePowerTimeSeriesParameter, devices, model)
 
@@ -128,9 +128,9 @@ function construct_device!(
     ::OptimizationContainer,
     ::PSY.System,
     ::ModelConstructStage,
-    ::DeviceModel{PSY.RegulationDevice{T}, FixedOutput},
+    ::DeviceModel{PSY.RegulationDevice{<: PSY.StaticInjection}, FixedOutput},
     network_model::NetworkModel{AreaBalancePowerModel},
-) where {T <: PSY.StaticInjection}
+)
     # There is no-op under FixedOutput formulation
     return
 end

--- a/src/devices_models/device_constructors/regulationdevice_constructor.jl
+++ b/src/devices_models/device_constructors/regulationdevice_constructor.jl
@@ -98,7 +98,13 @@ function construct_device!(
         network_model,
     )
 
-    add_constraints!(container, ParticipationAssignmentConstraint, devices, model, AreaBalancePowerModel)
+    add_constraints!(
+        container,
+        ParticipationAssignmentConstraint,
+        devices,
+        model,
+        AreaBalancePowerModel,
+    )
     objective_function!(container, devices, model)
     return
 end
@@ -107,7 +113,7 @@ function construct_device!(
     container::OptimizationContainer,
     sys::PSY.System,
     ::ArgumentConstructStage,
-    model::DeviceModel{PSY.RegulationDevice{<: PSY.StaticInjection}, FixedOutput},
+    model::DeviceModel{PSY.RegulationDevice{<:PSY.StaticInjection}, FixedOutput},
     network_model::NetworkModel{AreaBalancePowerModel},
 )
     devices = get_available_components(get_component_type(model), sys)
@@ -128,7 +134,7 @@ function construct_device!(
     ::OptimizationContainer,
     ::PSY.System,
     ::ModelConstructStage,
-    ::DeviceModel{PSY.RegulationDevice{<: PSY.StaticInjection}, FixedOutput},
+    ::DeviceModel{PSY.RegulationDevice{<:PSY.StaticInjection}, FixedOutput},
     network_model::NetworkModel{AreaBalancePowerModel},
 )
     # There is no-op under FixedOutput formulation

--- a/src/devices_models/device_constructors/renewablegeneration_constructor.jl
+++ b/src/devices_models/device_constructors/renewablegeneration_constructor.jl
@@ -3,7 +3,7 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{R, D},
-    network_model::NetworkModel{<: PM.AbstractPowerModel},
+    network_model::NetworkModel{<:PM.AbstractPowerModel},
 ) where {
     R <: PSY.RenewableGen,
     D <: AbstractRenewableDispatchFormulation,
@@ -59,12 +59,9 @@ function construct_device!(
     container::OptimizationContainer,
     sys::PSY.System,
     ::ModelConstructStage,
-    model::DeviceModel{R, <: AbstractRenewableDispatchFormulation},
-    network_model::NetworkModel{S},
-) where {
-    R <: PSY.RenewableGen,
-    S <: PM.AbstractPowerModel,
-}
+    model::DeviceModel{R, <:AbstractRenewableDispatchFormulation},
+    network_model::NetworkModel{<:PM.AbstractPowerModel},
+) where {R <: PSY.RenewableGen}
     devices =
         get_available_components(R, sys, get_attribute(model, "filter_function"))
 
@@ -106,7 +103,7 @@ function construct_device!(
     )
     add_feedforward_constraints!(container, model, devices)
 
-    objective_function!(container, devices, model, S)
+    objective_function!(container, devices, model, typeof(network_model).parameters[1])
 
     add_constraint_dual!(container, sys, model)
     return
@@ -117,7 +114,7 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{R, D},
-    network_model::NetworkModel{<: PM.AbstractActivePowerModel},
+    network_model::NetworkModel{<:PM.AbstractActivePowerModel},
 ) where {
     R <: PSY.RenewableGen,
     D <: AbstractRenewableDispatchFormulation,
@@ -164,12 +161,9 @@ function construct_device!(
     container::OptimizationContainer,
     sys::PSY.System,
     ::ModelConstructStage,
-    model::DeviceModel{R, <: AbstractRenewableDispatchFormulation},
-    network_model::NetworkModel{S},
-) where {
-    R <: PSY.RenewableGen,
-    S <: PM.AbstractActivePowerModel,
-}
+    model::DeviceModel{R, <:AbstractRenewableDispatchFormulation},
+    network_model::NetworkModel{<:PM.AbstractActivePowerModel},
+) where {R <: PSY.RenewableGen}
     devices =
         get_available_components(R, sys, get_attribute(model, "filter_function"))
 
@@ -202,7 +196,7 @@ function construct_device!(
     end
     add_feedforward_constraints!(container, model, devices)
 
-    objective_function!(container, devices, model, S)
+    objective_function!(container, devices, model, typeof(network_model).parameters[1])
 
     add_constraint_dual!(container, sys, model)
 
@@ -214,7 +208,7 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{R, FixedOutput},
-    network_model::NetworkModel{<: PM.AbstractPowerModel},
+    network_model::NetworkModel{<:PM.AbstractPowerModel},
 ) where {R <: PSY.RenewableGen}
     devices =
         get_available_components(R, sys, get_attribute(model, "filter_function"))
@@ -246,7 +240,7 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{R, FixedOutput},
-    network_model::NetworkModel{<: PM.AbstractActivePowerModel},
+    network_model::NetworkModel{<:PM.AbstractActivePowerModel},
 ) where {R <: PSY.RenewableGen}
     devices =
         get_available_components(R, sys, get_attribute(model, "filter_function"))
@@ -267,8 +261,8 @@ function construct_device!(
     container::OptimizationContainer,
     sys::PSY.System,
     ::ModelConstructStage,
-    model::DeviceModel{<: PSY.RenewableGen, FixedOutput},
-    network_model::NetworkModel{<: PM.AbstractPowerModel},
+    model::DeviceModel{<:PSY.RenewableGen, FixedOutput},
+    network_model::NetworkModel{<:PM.AbstractPowerModel},
 )
     # FixedOutput doesn't add any constraints to the model. This function covers
     # AbstractPowerModel and AbtractActivePowerModel

--- a/src/devices_models/device_constructors/renewablegeneration_constructor.jl
+++ b/src/devices_models/device_constructors/renewablegeneration_constructor.jl
@@ -3,11 +3,10 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{R, D},
-    network_model::NetworkModel{S},
+    network_model::NetworkModel{<: PM.AbstractPowerModel},
 ) where {
     R <: PSY.RenewableGen,
     D <: AbstractRenewableDispatchFormulation,
-    S <: PM.AbstractPowerModel,
 }
     devices =
         get_available_components(R, sys, get_attribute(model, "filter_function"))
@@ -60,11 +59,10 @@ function construct_device!(
     container::OptimizationContainer,
     sys::PSY.System,
     ::ModelConstructStage,
-    model::DeviceModel{R, D},
+    model::DeviceModel{R, <: AbstractRenewableDispatchFormulation},
     network_model::NetworkModel{S},
 ) where {
     R <: PSY.RenewableGen,
-    D <: AbstractRenewableDispatchFormulation,
     S <: PM.AbstractPowerModel,
 }
     devices =
@@ -119,11 +117,10 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{R, D},
-    network_model::NetworkModel{S},
+    network_model::NetworkModel{<: PM.AbstractActivePowerModel},
 ) where {
     R <: PSY.RenewableGen,
     D <: AbstractRenewableDispatchFormulation,
-    S <: PM.AbstractActivePowerModel,
 }
     devices =
         get_available_components(R, sys, get_attribute(model, "filter_function"))
@@ -167,11 +164,10 @@ function construct_device!(
     container::OptimizationContainer,
     sys::PSY.System,
     ::ModelConstructStage,
-    model::DeviceModel{R, D},
+    model::DeviceModel{R, <: AbstractRenewableDispatchFormulation},
     network_model::NetworkModel{S},
 ) where {
     R <: PSY.RenewableGen,
-    D <: AbstractRenewableDispatchFormulation,
     S <: PM.AbstractActivePowerModel,
 }
     devices =
@@ -218,8 +214,8 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{R, FixedOutput},
-    network_model::NetworkModel{S},
-) where {R <: PSY.RenewableGen, S <: PM.AbstractPowerModel}
+    network_model::NetworkModel{<: PM.AbstractPowerModel},
+) where {R <: PSY.RenewableGen}
     devices =
         get_available_components(R, sys, get_attribute(model, "filter_function"))
 
@@ -250,8 +246,8 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{R, FixedOutput},
-    network_model::NetworkModel{S},
-) where {R <: PSY.RenewableGen, S <: PM.AbstractActivePowerModel}
+    network_model::NetworkModel{<: PM.AbstractActivePowerModel},
+) where {R <: PSY.RenewableGen}
     devices =
         get_available_components(R, sys, get_attribute(model, "filter_function"))
 
@@ -271,9 +267,9 @@ function construct_device!(
     container::OptimizationContainer,
     sys::PSY.System,
     ::ModelConstructStage,
-    model::DeviceModel{R, FixedOutput},
-    network_model::NetworkModel{S},
-) where {R <: PSY.RenewableGen, S <: PM.AbstractPowerModel}
+    model::DeviceModel{<: PSY.RenewableGen, FixedOutput},
+    network_model::NetworkModel{<: PM.AbstractPowerModel},
+)
     # FixedOutput doesn't add any constraints to the model. This function covers
     # AbstractPowerModel and AbtractActivePowerModel
     return

--- a/src/devices_models/device_constructors/renewablegeneration_constructor.jl
+++ b/src/devices_models/device_constructors/renewablegeneration_constructor.jl
@@ -103,7 +103,7 @@ function construct_device!(
     )
     add_feedforward_constraints!(container, model, devices)
 
-    objective_function!(container, devices, model, typeof(network_model).parameters[1])
+    objective_function!(container, devices, model, get_network_formulation(network_model))
 
     add_constraint_dual!(container, sys, model)
     return
@@ -196,7 +196,7 @@ function construct_device!(
     end
     add_feedforward_constraints!(container, model, devices)
 
-    objective_function!(container, devices, model, typeof(network_model).parameters[1])
+    objective_function!(container, devices, model, get_network_formulation(network_model))
 
     add_constraint_dual!(container, sys, model)
 

--- a/src/devices_models/device_constructors/thermalgeneration_constructor.jl
+++ b/src/devices_models/device_constructors/thermalgeneration_constructor.jl
@@ -3,7 +3,7 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     device_model::DeviceModel{T, FixedOutput},
-    network_model::NetworkModel{<: PM.AbstractActivePowerModel},
+    network_model::NetworkModel{<:PM.AbstractActivePowerModel},
 ) where {T <: PSY.ThermalGen}
     devices =
         get_available_components(T, sys, get_attribute(device_model, "filter_function"))
@@ -23,8 +23,8 @@ function construct_device!(
     ::OptimizationContainer,
     ::PSY.System,
     ::ModelConstructStage,
-    ::DeviceModel{<: PSY.ThermalGen, FixedOutput},
-    network_model::NetworkModel{<: PM.AbstractPowerModel},
+    ::DeviceModel{<:PSY.ThermalGen, FixedOutput},
+    network_model::NetworkModel{<:PM.AbstractPowerModel},
 )
     # FixedOutput doesn't add any constraints to the model. This function covers
     # AbstractPowerModel and AbtractActivePowerModel
@@ -39,7 +39,7 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{T, D},
-    network_model::NetworkModel{<: PM.AbstractPowerModel},
+    network_model::NetworkModel{<:PM.AbstractPowerModel},
 ) where {
     T <: PSY.ThermalGen,
     D <: AbstractStandardUnitCommitment,
@@ -104,13 +104,9 @@ function construct_device!(
     container::OptimizationContainer,
     sys::PSY.System,
     ::ModelConstructStage,
-    model::DeviceModel{T, D},
-    network_model::NetworkModel{S},
-) where {
-    T <: PSY.ThermalGen,
-    D <: AbstractStandardUnitCommitment,
-    S <: PM.AbstractPowerModel,
-}
+    model::DeviceModel{T, <:AbstractStandardUnitCommitment},
+    network_model::NetworkModel{<:PM.AbstractPowerModel},
+) where {T <: PSY.ThermalGen}
     devices =
         get_available_components(T, sys, get_attribute(model, "filter_function"))
 
@@ -144,7 +140,7 @@ function construct_device!(
 
     add_feedforward_constraints!(container, model, devices)
 
-    objective_function!(container, devices, model, S)
+    objective_function!(container, devices, model, typeof(network_model).parameters[1])
     add_constraint_dual!(container, sys, model)
     return
 end
@@ -157,7 +153,7 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{T, D},
-    network_model::NetworkModel{<: PM.AbstractActivePowerModel},
+    network_model::NetworkModel{<:PM.AbstractActivePowerModel},
 ) where {T <: PSY.ThermalGen, D <: AbstractStandardUnitCommitment}
     devices =
         get_available_components(T, sys, get_attribute(model, "filter_function"))
@@ -211,12 +207,9 @@ function construct_device!(
     container::OptimizationContainer,
     sys::PSY.System,
     ::ModelConstructStage,
-    model::DeviceModel{T, <: AbstractStandardUnitCommitment},
-    network_model::NetworkModel{S},
-) where {
-    T <: PSY.ThermalGen,
-    S <: PM.AbstractActivePowerModel,
-}
+    model::DeviceModel{T, <:AbstractStandardUnitCommitment},
+    network_model::NetworkModel{<:PM.AbstractActivePowerModel},
+) where {T <: PSY.ThermalGen}
     devices =
         get_available_components(T, sys, get_attribute(model, "filter_function"))
     add_constraints!(
@@ -242,7 +235,7 @@ function construct_device!(
 
     add_feedforward_constraints!(container, model, devices)
 
-    objective_function!(container, devices, model, S)
+    objective_function!(container, devices, model, typeof(network_model).parameters[1])
 
     add_constraint_dual!(container, sys, model)
     return
@@ -256,7 +249,7 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{T, ThermalBasicUnitCommitment},
-    network_model::NetworkModel{<: PM.AbstractPowerModel},
+    network_model::NetworkModel{<:PM.AbstractPowerModel},
 ) where {T <: PSY.ThermalGen}
     devices =
         get_available_components(T, sys, get_attribute(model, "filter_function"))
@@ -317,8 +310,8 @@ function construct_device!(
     sys::PSY.System,
     ::ModelConstructStage,
     model::DeviceModel{T, ThermalBasicUnitCommitment},
-    network_model::NetworkModel{S},
-) where {T <: PSY.ThermalGen, S <: PM.AbstractPowerModel}
+    network_model::NetworkModel{<:PM.AbstractPowerModel},
+) where {T <: PSY.ThermalGen}
     devices =
         get_available_components(T, sys, get_attribute(model, "filter_function"))
 
@@ -351,7 +344,7 @@ function construct_device!(
 
     add_feedforward_constraints!(container, model, devices)
 
-    objective_function!(container, devices, model, S)
+    objective_function!(container, devices, model, typeof(network_model).parameters[1])
     add_constraint_dual!(container, sys, model)
     return
 end
@@ -364,8 +357,8 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{T, ThermalBasicUnitCommitment},
-    network_model::NetworkModel{S},
-) where {T <: PSY.ThermalGen, S <: PM.AbstractActivePowerModel}
+    network_model::NetworkModel{<:PM.AbstractActivePowerModel},
+) where {T <: PSY.ThermalGen}
     devices =
         get_available_components(T, sys, get_attribute(model, "filter_function"))
 
@@ -416,8 +409,8 @@ function construct_device!(
     sys::PSY.System,
     ::ModelConstructStage,
     model::DeviceModel{T, ThermalBasicUnitCommitment},
-    network_model::NetworkModel{S},
-) where {T <: PSY.ThermalGen, S <: PM.AbstractActivePowerModel}
+    network_model::NetworkModel{<:PM.AbstractActivePowerModel},
+) where {T <: PSY.ThermalGen}
     devices =
         get_available_components(T, sys, get_attribute(model, "filter_function"))
 
@@ -442,7 +435,7 @@ function construct_device!(
 
     add_feedforward_constraints!(container, model, devices)
 
-    objective_function!(container, devices, model, S)
+    objective_function!(container, devices, model, typeof(network_model).parameters[1])
     add_constraint_dual!(container, sys, model)
     return
 end
@@ -455,7 +448,7 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{T, ThermalStandardDispatch},
-    network_model::NetworkModel{<: PM.AbstractPowerModel},
+    network_model::NetworkModel{<:PM.AbstractPowerModel},
 ) where {T <: PSY.ThermalGen}
     devices =
         get_available_components(T, sys, get_attribute(model, "filter_function"))
@@ -513,8 +506,8 @@ function construct_device!(
     sys::PSY.System,
     ::ModelConstructStage,
     model::DeviceModel{T, ThermalStandardDispatch},
-    network_model::NetworkModel{S},
-) where {T <: PSY.ThermalGen, S <: PM.AbstractPowerModel}
+    network_model::NetworkModel{<:PM.AbstractPowerModel},
+) where {T <: PSY.ThermalGen}
     devices =
         get_available_components(T, sys, get_attribute(model, "filter_function"))
 
@@ -547,7 +540,7 @@ function construct_device!(
 
     add_feedforward_constraints!(container, model, devices)
 
-    objective_function!(container, devices, model, S)
+    objective_function!(container, devices, model, typeof(network_model).parameters[1])
     add_constraint_dual!(container, sys, model)
     return
 end
@@ -560,7 +553,7 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{T, ThermalStandardDispatch},
-    network_model::NetworkModel{<: PM.AbstractActivePowerModel},
+    network_model::NetworkModel{<:PM.AbstractActivePowerModel},
 ) where {T <: PSY.ThermalGen}
     devices =
         get_available_components(T, sys, get_attribute(model, "filter_function"))
@@ -609,8 +602,8 @@ function construct_device!(
     sys::PSY.System,
     ::ModelConstructStage,
     model::DeviceModel{T, ThermalStandardDispatch},
-    network_model::NetworkModel{S},
-) where {T <: PSY.ThermalGen, S <: PM.AbstractActivePowerModel}
+    network_model::NetworkModel{<:PM.AbstractActivePowerModel},
+) where {T <: PSY.ThermalGen}
     devices =
         get_available_components(T, sys, get_attribute(model, "filter_function"))
 
@@ -635,7 +628,7 @@ function construct_device!(
 
     add_feedforward_constraints!(container, model, devices)
 
-    objective_function!(container, devices, model, S)
+    objective_function!(container, devices, model, typeof(network_model).parameters[1])
     add_constraint_dual!(container, sys, model)
     return
 end
@@ -645,7 +638,7 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{T, D},
-    network_model::NetworkModel{<: PM.AbstractPowerModel},
+    network_model::NetworkModel{<:PM.AbstractPowerModel},
 ) where {
     T <: PSY.ThermalGen,
     D <: AbstractThermalDispatchFormulation,
@@ -700,12 +693,9 @@ function construct_device!(
     container::OptimizationContainer,
     sys::PSY.System,
     ::ModelConstructStage,
-    model::DeviceModel{T, <: AbstractThermalDispatchFormulation},
-    network_model::NetworkModel{S},
-) where {
-    T <: PSY.ThermalGen,
-    S <: PM.AbstractPowerModel,
-}
+    model::DeviceModel{T, <:AbstractThermalDispatchFormulation},
+    network_model::NetworkModel{<:PM.AbstractPowerModel},
+) where {T <: PSY.ThermalGen}
     devices =
         get_available_components(T, sys, get_attribute(model, "filter_function"))
 
@@ -737,7 +727,7 @@ function construct_device!(
 
     add_feedforward_constraints!(container, model, devices)
 
-    objective_function!(container, devices, model, S)
+    objective_function!(container, devices, model, typeof(network_model).parameters[1])
     add_constraint_dual!(container, sys, model)
     return
 end
@@ -747,7 +737,7 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{T, D},
-    network_model::NetworkModel{<: PM.AbstractActivePowerModel},
+    network_model::NetworkModel{<:PM.AbstractActivePowerModel},
 ) where {
     T <: PSY.ThermalGen,
     D <: AbstractThermalDispatchFormulation,
@@ -793,12 +783,9 @@ function construct_device!(
     container::OptimizationContainer,
     sys::PSY.System,
     ::ModelConstructStage,
-    model::DeviceModel{T, <: AbstractThermalDispatchFormulation},
-    network_model::NetworkModel{S},
-) where {
-    T <: PSY.ThermalGen,
-    S <: PM.AbstractActivePowerModel,
-}
+    model::DeviceModel{T, <:AbstractThermalDispatchFormulation},
+    network_model::NetworkModel{<:PM.AbstractActivePowerModel},
+) where {T <: PSY.ThermalGen}
     devices =
         get_available_components(T, sys, get_attribute(model, "filter_function"))
 
@@ -821,7 +808,7 @@ function construct_device!(
 
     add_feedforward_constraints!(container, model, devices)
 
-    objective_function!(container, devices, model, S)
+    objective_function!(container, devices, model, typeof(network_model).parameters[1])
     return
 end
 
@@ -830,7 +817,7 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{PSY.ThermalMultiStart, ThermalMultiStartUnitCommitment},
-    network_model::NetworkModel{<: PM.AbstractPowerModel},
+    network_model::NetworkModel{<:PM.AbstractPowerModel},
 )
     devices = get_available_components(PSY.ThermalMultiStart, sys)
 
@@ -913,8 +900,8 @@ function construct_device!(
     sys::PSY.System,
     ::ModelConstructStage,
     model::DeviceModel{PSY.ThermalMultiStart, ThermalMultiStartUnitCommitment},
-    network_model::NetworkModel{S},
-) where {S <: PM.AbstractPowerModel}
+    network_model::NetworkModel{<:PM.AbstractPowerModel},
+)
     devices = get_available_components(PSY.ThermalMultiStart, sys)
 
     add_constraints!(
@@ -964,7 +951,7 @@ function construct_device!(
 
     add_feedforward_constraints!(container, model, devices)
 
-    objective_function!(container, devices, model, S)
+    objective_function!(container, devices, model, typeof(network_model).parameters[1])
     add_constraint_dual!(container, sys, model)
     return
 end
@@ -974,7 +961,7 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{PSY.ThermalMultiStart, ThermalMultiStartUnitCommitment},
-    network_model::NetworkModel{<: PM.AbstractActivePowerModel},
+    network_model::NetworkModel{<:PM.AbstractActivePowerModel},
 )
     devices = get_available_components(PSY.ThermalMultiStart, sys)
 
@@ -1041,8 +1028,8 @@ function construct_device!(
     sys::PSY.System,
     ::ModelConstructStage,
     model::DeviceModel{PSY.ThermalMultiStart, ThermalMultiStartUnitCommitment},
-    network_model::NetworkModel{S},
-) where {S <: PM.AbstractActivePowerModel}
+    network_model::NetworkModel{<:PM.AbstractActivePowerModel},
+)
     devices = get_available_components(PSY.ThermalMultiStart, sys)
 
     initial_conditions!(container, devices, ThermalMultiStartUnitCommitment())
@@ -1086,7 +1073,7 @@ function construct_device!(
 
     add_feedforward_constraints!(container, model, devices)
 
-    objective_function!(container, devices, model, S)
+    objective_function!(container, devices, model, typeof(network_model).parameters[1])
     add_constraint_dual!(container, sys, model)
     return
 end
@@ -1096,7 +1083,7 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{T, ThermalCompactUnitCommitment},
-    network_model::NetworkModel{<: PM.AbstractPowerModel},
+    network_model::NetworkModel{<:PM.AbstractPowerModel},
 ) where {T <: PSY.ThermalGen}
     devices =
         get_available_components(T, sys, get_attribute(model, "filter_function"))
@@ -1168,8 +1155,8 @@ function construct_device!(
     sys::PSY.System,
     ::ModelConstructStage,
     model::DeviceModel{T, ThermalCompactUnitCommitment},
-    network_model::NetworkModel{S},
-) where {T <: PSY.ThermalGen, S <: PM.AbstractPowerModel}
+    network_model::NetworkModel{<:PM.AbstractPowerModel},
+) where {T <: PSY.ThermalGen}
     devices =
         get_available_components(T, sys, get_attribute(model, "filter_function"))
 
@@ -1204,7 +1191,7 @@ function construct_device!(
 
     add_feedforward_constraints!(container, model, devices)
 
-    objective_function!(container, devices, model, S)
+    objective_function!(container, devices, model, typeof(network_model).parameters[1])
     add_constraint_dual!(container, sys, model)
     return
 end
@@ -1214,7 +1201,7 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{T, ThermalCompactUnitCommitment},
-    network_model::NetworkModel{<: PM.AbstractActivePowerModel},
+    network_model::NetworkModel{<:PM.AbstractActivePowerModel},
 ) where {T <: PSY.ThermalGen}
     devices =
         get_available_components(T, sys, get_attribute(model, "filter_function"))
@@ -1279,8 +1266,8 @@ function construct_device!(
     sys::PSY.System,
     ::ModelConstructStage,
     model::DeviceModel{T, ThermalCompactUnitCommitment},
-    network_model::NetworkModel{S},
-) where {T <: PSY.ThermalGen, S <: PM.AbstractActivePowerModel}
+    network_model::NetworkModel{<:PM.AbstractActivePowerModel},
+) where {T <: PSY.ThermalGen}
     devices =
         get_available_components(T, sys, get_attribute(model, "filter_function"))
 
@@ -1307,7 +1294,7 @@ function construct_device!(
 
     add_feedforward_constraints!(container, model, devices)
 
-    objective_function!(container, devices, model, S)
+    objective_function!(container, devices, model, typeof(network_model).parameters[1])
     add_constraint_dual!(container, sys, model)
     return
 end
@@ -1317,7 +1304,7 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{T, ThermalBasicCompactUnitCommitment},
-    network_model::NetworkModel{<: PM.AbstractPowerModel},
+    network_model::NetworkModel{<:PM.AbstractPowerModel},
 ) where {T <: PSY.ThermalGen}
     devices =
         get_available_components(T, sys, get_attribute(model, "filter_function"))
@@ -1387,8 +1374,8 @@ function construct_device!(
     sys::PSY.System,
     ::ModelConstructStage,
     model::DeviceModel{T, ThermalBasicCompactUnitCommitment},
-    network_model::NetworkModel{S},
-) where {T <: PSY.ThermalGen, S <: PM.AbstractPowerModel}
+    network_model::NetworkModel{<:PM.AbstractPowerModel},
+) where {T <: PSY.ThermalGen}
     devices =
         get_available_components(T, sys, get_attribute(model, "filter_function"))
 
@@ -1421,7 +1408,7 @@ function construct_device!(
 
     add_feedforward_constraints!(container, model, devices)
 
-    objective_function!(container, devices, model, S)
+    objective_function!(container, devices, model, typeof(network_model).parameters[1])
     add_constraint_dual!(container, sys, model)
     return
 end
@@ -1431,7 +1418,7 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{T, ThermalBasicCompactUnitCommitment},
-    network_model::NetworkModel{<: PM.AbstractActivePowerModel},
+    network_model::NetworkModel{<:PM.AbstractActivePowerModel},
 ) where {T <: PSY.ThermalGen}
     devices =
         get_available_components(T, sys, get_attribute(model, "filter_function"))
@@ -1494,8 +1481,8 @@ function construct_device!(
     sys::PSY.System,
     ::ModelConstructStage,
     model::DeviceModel{T, ThermalBasicCompactUnitCommitment},
-    network_model::NetworkModel{S},
-) where {T <: PSY.ThermalGen, S <: PM.AbstractActivePowerModel}
+    network_model::NetworkModel{<:PM.AbstractActivePowerModel},
+) where {T <: PSY.ThermalGen}
     devices =
         get_available_components(T, sys, get_attribute(model, "filter_function"))
 
@@ -1520,7 +1507,7 @@ function construct_device!(
 
     add_feedforward_constraints!(container, model, devices)
 
-    objective_function!(container, devices, model, S)
+    objective_function!(container, devices, model, typeof(network_model).parameters[1])
     add_constraint_dual!(container, sys, model)
     return
 end
@@ -1530,7 +1517,7 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{T, ThermalCompactDispatch},
-    network_model::NetworkModel{<: PM.AbstractPowerModel},
+    network_model::NetworkModel{<:PM.AbstractPowerModel},
 ) where {T <: PSY.ThermalGen}
     devices =
         get_available_components(T, sys, get_attribute(model, "filter_function"))
@@ -1614,8 +1601,8 @@ function construct_device!(
     sys::PSY.System,
     ::ModelConstructStage,
     model::DeviceModel{T, ThermalCompactDispatch},
-    network_model::NetworkModel{S},
-) where {T <: PSY.ThermalGen, S <: PM.AbstractPowerModel}
+    network_model::NetworkModel{<:PM.AbstractPowerModel},
+) where {T <: PSY.ThermalGen}
     devices =
         get_available_components(T, sys, get_attribute(model, "filter_function"))
 
@@ -1648,7 +1635,7 @@ function construct_device!(
 
     add_feedforward_constraints!(container, model, devices)
 
-    objective_function!(container, devices, model, S)
+    objective_function!(container, devices, model, typeof(network_model).parameters[1])
     add_constraint_dual!(container, sys, model)
     return
 end
@@ -1658,7 +1645,7 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{T, ThermalCompactDispatch},
-    network_model::NetworkModel{<: PM.AbstractActivePowerModel},
+    network_model::NetworkModel{<:PM.AbstractActivePowerModel},
 ) where {T <: PSY.ThermalGen}
     devices =
         get_available_components(T, sys, get_attribute(model, "filter_function"))
@@ -1717,8 +1704,8 @@ function construct_device!(
     sys::PSY.System,
     ::ModelConstructStage,
     model::DeviceModel{T, ThermalCompactDispatch},
-    network_model::NetworkModel{S},
-) where {T <: PSY.ThermalGen, S <: PM.AbstractActivePowerModel}
+    network_model::NetworkModel{<:PM.AbstractActivePowerModel},
+) where {T <: PSY.ThermalGen}
     devices =
         get_available_components(T, sys, get_attribute(model, "filter_function"))
 
@@ -1743,7 +1730,7 @@ function construct_device!(
 
     add_feedforward_constraints!(container, model, devices)
 
-    objective_function!(container, devices, model, S)
+    objective_function!(container, devices, model, typeof(network_model).parameters[1])
     add_constraint_dual!(container, sys, model)
     return
 end

--- a/src/devices_models/device_constructors/thermalgeneration_constructor.jl
+++ b/src/devices_models/device_constructors/thermalgeneration_constructor.jl
@@ -140,7 +140,7 @@ function construct_device!(
 
     add_feedforward_constraints!(container, model, devices)
 
-    objective_function!(container, devices, model, typeof(network_model).parameters[1])
+    objective_function!(container, devices, model, get_network_formulation(network_model))
     add_constraint_dual!(container, sys, model)
     return
 end
@@ -235,7 +235,7 @@ function construct_device!(
 
     add_feedforward_constraints!(container, model, devices)
 
-    objective_function!(container, devices, model, typeof(network_model).parameters[1])
+    objective_function!(container, devices, model, get_network_formulation(network_model))
 
     add_constraint_dual!(container, sys, model)
     return
@@ -344,7 +344,7 @@ function construct_device!(
 
     add_feedforward_constraints!(container, model, devices)
 
-    objective_function!(container, devices, model, typeof(network_model).parameters[1])
+    objective_function!(container, devices, model, get_network_formulation(network_model))
     add_constraint_dual!(container, sys, model)
     return
 end
@@ -435,7 +435,7 @@ function construct_device!(
 
     add_feedforward_constraints!(container, model, devices)
 
-    objective_function!(container, devices, model, typeof(network_model).parameters[1])
+    objective_function!(container, devices, model, get_network_formulation(network_model))
     add_constraint_dual!(container, sys, model)
     return
 end
@@ -540,7 +540,7 @@ function construct_device!(
 
     add_feedforward_constraints!(container, model, devices)
 
-    objective_function!(container, devices, model, typeof(network_model).parameters[1])
+    objective_function!(container, devices, model, get_network_formulation(network_model))
     add_constraint_dual!(container, sys, model)
     return
 end
@@ -628,7 +628,7 @@ function construct_device!(
 
     add_feedforward_constraints!(container, model, devices)
 
-    objective_function!(container, devices, model, typeof(network_model).parameters[1])
+    objective_function!(container, devices, model, get_network_formulation(network_model))
     add_constraint_dual!(container, sys, model)
     return
 end
@@ -727,7 +727,7 @@ function construct_device!(
 
     add_feedforward_constraints!(container, model, devices)
 
-    objective_function!(container, devices, model, typeof(network_model).parameters[1])
+    objective_function!(container, devices, model, get_network_formulation(network_model))
     add_constraint_dual!(container, sys, model)
     return
 end
@@ -808,7 +808,7 @@ function construct_device!(
 
     add_feedforward_constraints!(container, model, devices)
 
-    objective_function!(container, devices, model, typeof(network_model).parameters[1])
+    objective_function!(container, devices, model, get_network_formulation(network_model))
     return
 end
 
@@ -951,7 +951,7 @@ function construct_device!(
 
     add_feedforward_constraints!(container, model, devices)
 
-    objective_function!(container, devices, model, typeof(network_model).parameters[1])
+    objective_function!(container, devices, model, get_network_formulation(network_model))
     add_constraint_dual!(container, sys, model)
     return
 end
@@ -1073,7 +1073,7 @@ function construct_device!(
 
     add_feedforward_constraints!(container, model, devices)
 
-    objective_function!(container, devices, model, typeof(network_model).parameters[1])
+    objective_function!(container, devices, model, get_network_formulation(network_model))
     add_constraint_dual!(container, sys, model)
     return
 end
@@ -1191,7 +1191,7 @@ function construct_device!(
 
     add_feedforward_constraints!(container, model, devices)
 
-    objective_function!(container, devices, model, typeof(network_model).parameters[1])
+    objective_function!(container, devices, model, get_network_formulation(network_model))
     add_constraint_dual!(container, sys, model)
     return
 end
@@ -1294,7 +1294,7 @@ function construct_device!(
 
     add_feedforward_constraints!(container, model, devices)
 
-    objective_function!(container, devices, model, typeof(network_model).parameters[1])
+    objective_function!(container, devices, model, get_network_formulation(network_model))
     add_constraint_dual!(container, sys, model)
     return
 end
@@ -1408,7 +1408,7 @@ function construct_device!(
 
     add_feedforward_constraints!(container, model, devices)
 
-    objective_function!(container, devices, model, typeof(network_model).parameters[1])
+    objective_function!(container, devices, model, get_network_formulation(network_model))
     add_constraint_dual!(container, sys, model)
     return
 end
@@ -1507,7 +1507,7 @@ function construct_device!(
 
     add_feedforward_constraints!(container, model, devices)
 
-    objective_function!(container, devices, model, typeof(network_model).parameters[1])
+    objective_function!(container, devices, model, get_network_formulation(network_model))
     add_constraint_dual!(container, sys, model)
     return
 end
@@ -1635,7 +1635,7 @@ function construct_device!(
 
     add_feedforward_constraints!(container, model, devices)
 
-    objective_function!(container, devices, model, typeof(network_model).parameters[1])
+    objective_function!(container, devices, model, get_network_formulation(network_model))
     add_constraint_dual!(container, sys, model)
     return
 end
@@ -1730,7 +1730,7 @@ function construct_device!(
 
     add_feedforward_constraints!(container, model, devices)
 
-    objective_function!(container, devices, model, typeof(network_model).parameters[1])
+    objective_function!(container, devices, model, get_network_formulation(network_model))
     add_constraint_dual!(container, sys, model)
     return
 end

--- a/src/devices_models/device_constructors/thermalgeneration_constructor.jl
+++ b/src/devices_models/device_constructors/thermalgeneration_constructor.jl
@@ -2,18 +2,18 @@ function construct_device!(
     container::OptimizationContainer,
     sys::PSY.System,
     ::ArgumentConstructStage,
-    ::DeviceModel{T, FixedOutput},
-    network_model::NetworkModel{S},
-) where {T <: PSY.ThermalGen, S <: PM.AbstractActivePowerModel}
+    device_model::DeviceModel{T, FixedOutput},
+    network_model::NetworkModel{<: PM.AbstractActivePowerModel},
+) where {T <: PSY.ThermalGen}
     devices =
-        get_available_components(T, sys, get_attribute(model, "filter_function"))
-    add_parameters!(container, ActivePowerTimeSeriesParameter, devices, model)
+        get_available_components(T, sys, get_attribute(device_model, "filter_function"))
+    add_parameters!(container, ActivePowerTimeSeriesParameter, devices, device_model)
     add_to_expression!(
         container,
         ActivePowerBalance,
         ActivePowerTimeSeriesParameter,
         devices,
-        model,
+        device_model,
         network_model,
     )
     return
@@ -23,9 +23,9 @@ function construct_device!(
     ::OptimizationContainer,
     ::PSY.System,
     ::ModelConstructStage,
-    ::DeviceModel{T, FixedOutput},
-    network_model::NetworkModel{S},
-) where {T <: PSY.ThermalGen, S <: PM.AbstractPowerModel}
+    ::DeviceModel{<: PSY.ThermalGen, FixedOutput},
+    network_model::NetworkModel{<: PM.AbstractPowerModel},
+)
     # FixedOutput doesn't add any constraints to the model. This function covers
     # AbstractPowerModel and AbtractActivePowerModel
     return
@@ -39,11 +39,10 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{T, D},
-    network_model::NetworkModel{S},
+    network_model::NetworkModel{<: PM.AbstractPowerModel},
 ) where {
     T <: PSY.ThermalGen,
     D <: AbstractStandardUnitCommitment,
-    S <: PM.AbstractPowerModel,
 }
     devices =
         get_available_components(T, sys, get_attribute(model, "filter_function"))
@@ -158,12 +157,8 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{T, D},
-    network_model::NetworkModel{S},
-) where {
-    T <: PSY.ThermalGen,
-    D <: AbstractStandardUnitCommitment,
-    S <: PM.AbstractActivePowerModel,
-}
+    network_model::NetworkModel{<: PM.AbstractActivePowerModel},
+) where {T <: PSY.ThermalGen, D <: AbstractStandardUnitCommitment}
     devices =
         get_available_components(T, sys, get_attribute(model, "filter_function"))
 
@@ -216,11 +211,10 @@ function construct_device!(
     container::OptimizationContainer,
     sys::PSY.System,
     ::ModelConstructStage,
-    model::DeviceModel{T, D},
+    model::DeviceModel{T, <: AbstractStandardUnitCommitment},
     network_model::NetworkModel{S},
 ) where {
     T <: PSY.ThermalGen,
-    D <: AbstractStandardUnitCommitment,
     S <: PM.AbstractActivePowerModel,
 }
     devices =
@@ -262,8 +256,8 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{T, ThermalBasicUnitCommitment},
-    network_model::NetworkModel{S},
-) where {T <: PSY.ThermalGen, S <: PM.AbstractPowerModel}
+    network_model::NetworkModel{<: PM.AbstractPowerModel},
+) where {T <: PSY.ThermalGen}
     devices =
         get_available_components(T, sys, get_attribute(model, "filter_function"))
 
@@ -461,8 +455,8 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{T, ThermalStandardDispatch},
-    network_model::NetworkModel{S},
-) where {T <: PSY.ThermalGen, S <: PM.AbstractPowerModel}
+    network_model::NetworkModel{<: PM.AbstractPowerModel},
+) where {T <: PSY.ThermalGen}
     devices =
         get_available_components(T, sys, get_attribute(model, "filter_function"))
 
@@ -566,8 +560,8 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{T, ThermalStandardDispatch},
-    network_model::NetworkModel{S},
-) where {T <: PSY.ThermalGen, S <: PM.AbstractActivePowerModel}
+    network_model::NetworkModel{<: PM.AbstractActivePowerModel},
+) where {T <: PSY.ThermalGen}
     devices =
         get_available_components(T, sys, get_attribute(model, "filter_function"))
 
@@ -651,11 +645,10 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{T, D},
-    network_model::NetworkModel{S},
+    network_model::NetworkModel{<: PM.AbstractPowerModel},
 ) where {
     T <: PSY.ThermalGen,
     D <: AbstractThermalDispatchFormulation,
-    S <: PM.AbstractPowerModel,
 }
     devices =
         get_available_components(T, sys, get_attribute(model, "filter_function"))
@@ -707,11 +700,10 @@ function construct_device!(
     container::OptimizationContainer,
     sys::PSY.System,
     ::ModelConstructStage,
-    model::DeviceModel{T, D},
+    model::DeviceModel{T, <: AbstractThermalDispatchFormulation},
     network_model::NetworkModel{S},
 ) where {
     T <: PSY.ThermalGen,
-    D <: AbstractThermalDispatchFormulation,
     S <: PM.AbstractPowerModel,
 }
     devices =
@@ -755,11 +747,10 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{T, D},
-    network_model::NetworkModel{S},
+    network_model::NetworkModel{<: PM.AbstractActivePowerModel},
 ) where {
     T <: PSY.ThermalGen,
     D <: AbstractThermalDispatchFormulation,
-    S <: PM.AbstractActivePowerModel,
 }
     devices =
         get_available_components(T, sys, get_attribute(model, "filter_function"))
@@ -802,11 +793,10 @@ function construct_device!(
     container::OptimizationContainer,
     sys::PSY.System,
     ::ModelConstructStage,
-    model::DeviceModel{T, D},
+    model::DeviceModel{T, <: AbstractThermalDispatchFormulation},
     network_model::NetworkModel{S},
 ) where {
     T <: PSY.ThermalGen,
-    D <: AbstractThermalDispatchFormulation,
     S <: PM.AbstractActivePowerModel,
 }
     devices =
@@ -840,8 +830,8 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{PSY.ThermalMultiStart, ThermalMultiStartUnitCommitment},
-    network_model::NetworkModel{S},
-) where {S <: PM.AbstractPowerModel}
+    network_model::NetworkModel{<: PM.AbstractPowerModel},
+)
     devices = get_available_components(PSY.ThermalMultiStart, sys)
 
     add_variables!(
@@ -984,8 +974,8 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{PSY.ThermalMultiStart, ThermalMultiStartUnitCommitment},
-    network_model::NetworkModel{S},
-) where {S <: PM.AbstractActivePowerModel}
+    network_model::NetworkModel{<: PM.AbstractActivePowerModel},
+)
     devices = get_available_components(PSY.ThermalMultiStart, sys)
 
     add_variables!(
@@ -1106,8 +1096,8 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{T, ThermalCompactUnitCommitment},
-    network_model::NetworkModel{S},
-) where {T <: PSY.ThermalGen, S <: PM.AbstractPowerModel}
+    network_model::NetworkModel{<: PM.AbstractPowerModel},
+) where {T <: PSY.ThermalGen}
     devices =
         get_available_components(T, sys, get_attribute(model, "filter_function"))
 
@@ -1224,8 +1214,8 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{T, ThermalCompactUnitCommitment},
-    network_model::NetworkModel{S},
-) where {T <: PSY.ThermalGen, S <: PM.AbstractActivePowerModel}
+    network_model::NetworkModel{<: PM.AbstractActivePowerModel},
+) where {T <: PSY.ThermalGen}
     devices =
         get_available_components(T, sys, get_attribute(model, "filter_function"))
 
@@ -1327,8 +1317,8 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{T, ThermalBasicCompactUnitCommitment},
-    network_model::NetworkModel{S},
-) where {T <: PSY.ThermalGen, S <: PM.AbstractPowerModel}
+    network_model::NetworkModel{<: PM.AbstractPowerModel},
+) where {T <: PSY.ThermalGen}
     devices =
         get_available_components(T, sys, get_attribute(model, "filter_function"))
 
@@ -1441,8 +1431,8 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{T, ThermalBasicCompactUnitCommitment},
-    network_model::NetworkModel{S},
-) where {T <: PSY.ThermalGen, S <: PM.AbstractActivePowerModel}
+    network_model::NetworkModel{<: PM.AbstractActivePowerModel},
+) where {T <: PSY.ThermalGen}
     devices =
         get_available_components(T, sys, get_attribute(model, "filter_function"))
 
@@ -1540,8 +1530,8 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{T, ThermalCompactDispatch},
-    network_model::NetworkModel{S},
-) where {T <: PSY.ThermalGen, S <: PM.AbstractPowerModel}
+    network_model::NetworkModel{<: PM.AbstractPowerModel},
+) where {T <: PSY.ThermalGen}
     devices =
         get_available_components(T, sys, get_attribute(model, "filter_function"))
 
@@ -1668,8 +1658,8 @@ function construct_device!(
     sys::PSY.System,
     ::ArgumentConstructStage,
     model::DeviceModel{T, ThermalCompactDispatch},
-    network_model::NetworkModel{S},
-) where {T <: PSY.ThermalGen, S <: PM.AbstractActivePowerModel}
+    network_model::NetworkModel{<: PM.AbstractActivePowerModel},
+) where {T <: PSY.ThermalGen}
     devices =
         get_available_components(T, sys, get_attribute(model, "filter_function"))
 


### PR DESCRIPTION
This PR allows SnoopCompile.jl to generate precompile statements for PowerSimulations.jl. In many cases I removed unused parameterized type variables. In other cases they were being used and I replaced uses with `typeof(x)`. There should not be any functional or performance difference.

If this change is approved, I can move forward with integrating SnoopCompile.jl with this package in a separate branch. The only other realistic alternative is to report an issue with SnoopCompile.jl and see if they can help.
