### PR TITLE
add mipgap to caputred stats

### DIFF
--- a/src/utils/jump_utils.jl
+++ b/src/utils/jump_utils.jl
@@ -243,6 +243,7 @@ function _summary_to_dict!(optimizer_stats::OptimizerStats, jump_model::JuMP.Mod
         :objective_bound, # Union{Missing,Float64}
         :dual_objective_value, # Union{Missing,Float64}
         # Work counters
+        :relative_gap, # Union{Missing,Int}
         :barrier_iterations, # Union{Missing,Int}
         :simplex_iterations, # Union{Missing,Int}
         :node_count, # Union{Missing,Int}


### PR DESCRIPTION
You need to use the setting `detailed_stats` to get it. 