### PR TITLE
Jd/thermal modeling changes

### DIFF
--- a/src/devices_models/devices/AC_branches.jl
+++ b/src/devices_models/devices/AC_branches.jl
@@ -24,8 +24,7 @@ get_variable_binary(::PhaseShifterAngle, ::Type{PSY.PhaseShiftingTransformer}, :
 get_parameter_multiplier(::FixValueParameter, ::PSY.ACBranch, ::StaticBranch) = 1.0
 get_variable_multiplier(::PhaseShifterAngle, d::PSY.PhaseShiftingTransformer, ::PhaseAngleControl) = 1.0/PSY.get_x(d)
 
-get_initial_conditions_device_model(::OperationModel, ::DeviceModel{T, <:AbstractBranchFormulation}) where {T <: PSY.ACBranch} = DeviceModel(T, StaticBranch)
-get_initial_conditions_device_model(::OperationModel, ::DeviceModel{T, <:AbstractBranchFormulation},) where {T <: PSY.MonitoredLine} = DeviceModel(T, StaticBranchUnbounded)
+get_initial_conditions_device_model(::OperationModel, ::DeviceModel{T, U}) where {T <: PSY.ACBranch, U <: <:AbstractBranchFormulation} = DeviceModel(T, U)
 
 #! format: on
 function get_default_time_series_names(

--- a/src/devices_models/devices/AC_branches.jl
+++ b/src/devices_models/devices/AC_branches.jl
@@ -24,7 +24,7 @@ get_variable_binary(::PhaseShifterAngle, ::Type{PSY.PhaseShiftingTransformer}, :
 get_parameter_multiplier(::FixValueParameter, ::PSY.ACBranch, ::StaticBranch) = 1.0
 get_variable_multiplier(::PhaseShifterAngle, d::PSY.PhaseShiftingTransformer, ::PhaseAngleControl) = 1.0/PSY.get_x(d)
 
-get_initial_conditions_device_model(::OperationModel, ::DeviceModel{T, U}) where {T <: PSY.ACBranch, U <: <:AbstractBranchFormulation} = DeviceModel(T, U)
+get_initial_conditions_device_model(::OperationModel, ::DeviceModel{T, U}) where {T <: PSY.ACBranch, U <: AbstractBranchFormulation} = DeviceModel(T, U)
 
 #! format: on
 function get_default_time_series_names(

--- a/src/devices_models/devices/thermal_generation.jl
+++ b/src/devices_models/devices/thermal_generation.jl
@@ -472,7 +472,8 @@ function add_constraints!(
                 max(limits.max - startup_shutdown_limits.startup, 0.0) * varon[name, t]
             )
 
-            con_lb[name, t] = JuMP.@constraint(get_jump_model(container), varp[name, t] >= 0.0)
+            con_lb[name, t] =
+                JuMP.@constraint(get_jump_model(container), varp[name, t] >= 0.0)
 
             if t != length(time_steps)
                 con_off[name, t] = JuMP.@constraint(
@@ -524,7 +525,10 @@ function add_constraints!(
                 JuMP.set_lower_bound(varp[name, t], 0.0)
             end
             con_lb[name, t] =
-                JuMP.@constraint(get_jump_model(container), expression_products[name, t] >= 0)
+                JuMP.@constraint(
+                    get_jump_model(container),
+                    expression_products[name, t] >= 0
+                )
         end
     end
     return

--- a/src/devices_models/devices/thermal_generation.jl
+++ b/src/devices_models/devices/thermal_generation.jl
@@ -474,9 +474,7 @@ function add_constraints!(
 
             con_lb[name, t] = JuMP.@constraint(container.JuMPmodel, varp[name, t] >= 0.0)
 
-            if t == length(time_steps)
-                continue
-            else
+            if t != length(time_steps)
                 con_off[name, t] = JuMP.@constraint(
                     container.JuMPmodel,
                     varp[name, t] <=
@@ -587,9 +585,7 @@ function add_constraints!(
                 (limits.max - limits.min) * varstatus[name, t] -
                 max(limits.max - startup_shutdown_limits.startup, 0) * varon[name, t]
             )
-            if t == length(time_steps)
-                continue
-            else
+            if t != length(time_steps)
                 con_off[name, t] = JuMP.@constraint(
                     container.JuMPmodel,
                     expression_products[name, t] <=


### PR DESCRIPTION
This PR fixes some loops in ThermalMultiStart and also uses nothing for LB on variables for UC. The rationale for this is that in some cases thermal units with negative limits are being used to represent transactions with other areas where the power is negative. This is a work around while we implement a more rigorous way to do inter-regional transactions. 