### PR TITLE
Serialize System components to HDF5

### DIFF
--- a/src/operation/decision_model.jl
+++ b/src/operation/decision_model.jl
@@ -268,8 +268,8 @@ end
 
 function validate_time_series(model::DecisionModel{<:DefaultDecisionProblem})
     sys = get_system(model)
-    _, _, forecast_count = PSY.get_time_series_counts(sys)
-    if forecast_count < 1
+    counts = PSY.get_time_series_counts(sys)
+    if counts.forecast_count < 1
         error(
             "The system does not contain forecast data. A DecisionModel can't be built.",
         )

--- a/src/operation/emulation_model.jl
+++ b/src/operation/emulation_model.jl
@@ -247,8 +247,8 @@ end
 
 function validate_time_series(model::EmulationModel{<:DefaultEmulationProblem})
     sys = get_system(model)
-    _, ts_count, _ = PSY.get_time_series_counts(sys)
-    if ts_count < 1
+    counts = PSY.get_time_series_counts(sys)
+    if counts.static_time_series_count < 1
         error(
             "The system does not contain Static TimeSeries data. An Emulation model can't be formulated.",
         )

--- a/src/simulation/in_memory_simulation_store.jl
+++ b/src/simulation/in_memory_simulation_store.jl
@@ -271,3 +271,5 @@ function write_optimizer_stats!(
     write_optimizer_stats!(em_data, stats, index)
     return
 end
+
+serialize_system!(::InMemorySimulationStore, ::PSY.System) = nothing

--- a/src/simulation/simulation.jl
+++ b/src/simulation/simulation.jl
@@ -590,13 +590,17 @@ function _setup_simulation_partitions(sim::Simulation)
 
     open_store(HdfSimulationStore, get_store_dir(sim), "w") do store
         set_simulation_store!(sim, store)
-        _initialize_problem_storage!(
-            sim,
-            DEFAULT_SIMULATION_STORE_CACHE_SIZE_MiB,
-            MIN_CACHE_FLUSH_SIZE_MiB,
-        )
+        try
+            _initialize_problem_storage!(
+                sim,
+                DEFAULT_SIMULATION_STORE_CACHE_SIZE_MiB,
+                MIN_CACHE_FLUSH_SIZE_MiB,
+            )
+            _serialize_systems_to_store!(store, sim)
+        finally
+            set_simulation_store!(sim, nothing)
+        end
     end
-    set_simulation_store!(sim, nothing)
 end
 
 """
@@ -1000,6 +1004,10 @@ function execute!(sim::Simulation; kwargs...)
                     end
                     @info ("\n$(RUN_SIMULATION_TIMER)\n")
                     set_simulation_status!(sim, RunStatus.SUCCESSFUL)
+                    if isnothing(sim.internal.partitions)
+                        # Partitioned simulations serialize the systems once during build.
+                        _serialize_systems_to_store!(store, sim)
+                    end
                     log_cache_hit_percentages(store)
                 catch e
                     set_simulation_status!(sim, RunStatus.FAILED)
@@ -1082,6 +1090,18 @@ function serialize_simulation(sim::Simulation; path = nothing, force = false)
     Serialization.serialize(filename, obj)
     @info "Serialized simulation name = $(get_name(sim))" directory
     return directory
+end
+
+function _serialize_systems_to_store!(store::SimulationStore, sim::Simulation)
+    simulation_models = get_models(sim)
+    for dm in get_decision_models(simulation_models)
+        serialize_system!(store, get_system(dm))
+    end
+
+    em = get_emulation_model(simulation_models)
+    if !isnothing(em)
+        serialize_system!(store, get_system(em))
+    end
 end
 
 function deserialize_model(

--- a/src/simulation/simulation_problem_results.jl
+++ b/src/simulation/simulation_problem_results.jl
@@ -118,7 +118,7 @@ If the simulation was configured to serialize all systems to file then the retur
 will include all data. If that was not configured then the returned system will include
 all data except time series data.
 """
-function get_system!(results::SimulationProblemResults)
+function get_system!(results::SimulationProblemResults; kwargs...)
     !isnothing(results.system) && return results.system
 
     file = joinpath(
@@ -128,7 +128,9 @@ function get_system!(results::SimulationProblemResults)
         make_system_filename(results.system_uuid),
     )
 
-    if isfile(file)
+    # This flag should remain unpublished because it should never be needed
+    # by the general audience.
+    if !get(kwargs, :use_h5_system, false) && isfile(file)
         system = PSY.System(file; time_series_read_only = true)
         @info "De-serialized the system from files."
     else
@@ -154,7 +156,7 @@ end
 
 function _deserialize_system(::SimulationProblemResults, ::InMemorySimulationStore)
     # This should never be necessary because the system is guaranteed to be in memory.
-    error("Deserializing a system from the InMemorySimulationStore is not supported.") 
+    error("Deserializing a system from the InMemorySimulationStore is not supported.")
 end
 
 """

--- a/src/simulation/simulation_problem_results.jl
+++ b/src/simulation/simulation_problem_results.jl
@@ -113,16 +113,48 @@ get_timestamps(result::SimulationProblemResults) = result.timestamps
 """
 Return the system used for the problem. If the system hasn't already been deserialized or
 set with [`set_system!`](@ref) then deserialize and store it.
+
+If the simulation was configured to serialize all systems to file then the returned system
+will include all data. If that was not configured then the returned system will include
+all data except time series data.
 """
 function get_system!(results::SimulationProblemResults)
+    !isnothing(results.system) && return results.system
+
     file = joinpath(
         results.execution_path,
         "problems",
         results.problem,
         make_system_filename(results.system_uuid),
     )
-    results.system = PSY.System(file; time_series_read_only = true)
+
+    if isfile(file)
+        system = PSY.System(file; time_series_read_only = true)
+        @info "De-serialized the system from files."
+    else
+        system = _deserialize_system(results, results.store)
+    end
+
+    results.system = system
     return results.system
+end
+
+function _deserialize_system(results::SimulationProblemResults, ::Nothing)
+    open_store(
+        HdfSimulationStore,
+        joinpath(get_execution_path(results), "data_store"),
+        "r",
+    ) do store
+        system = deserialize_system(store, results.system_uuid)
+        @info "De-serialized the system from the simulation store. The system does " *
+              "not include time series data."
+        return system
+    end
+end
+
+function _deserialize_system(::SimulationProblemResults, ::InMemorySimulationStore)
+    # This should never be necessary because the system is guaranteed to be in memory.
+    error("Deserializing a system from the InMemorySimulationStore is not supported.") 
 end
 
 """
@@ -593,11 +625,8 @@ Return the optimizer stats for the problem as a DataFrame.
   - `store::SimulationStore`: a store that has been opened for reading
 """
 function read_optimizer_stats(res::SimulationProblemResults; store = nothing)
-    if store === nothing && res.store !== nothing
-        # In this case we have an InMemorySimulationStore.
-        store = res.store
-    end
-    return _read_optimizer_stats(res, store)
+    _store = isnothing(store) ? res.store : store
+    return _read_optimizer_stats(res, _store)
 end
 
 function _read_optimizer_stats(res::SimulationProblemResults, ::Nothing)


### PR DESCRIPTION
Objective: The simulations postprocessing code in PowerAnalytics.jl needs to have access to the systems used by the simulations. Those systems are not serialized if the user opts out of that feature. Ensure that these are always available.

This is the PowerSimulations portion of the solution. I added comparable branches in PowerSystems.jl and InfrastructureSystems.jl. Let me know if the interfaces here meet your needs and then I’ll open sibling PRs.