### PR TITLE
Fix caching behaviors: #1070, #1072, #1074

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,8 @@ For example, an annual production cost modeling simulation can be created by for
 
 - Integrated Resource Planning
 - Production Cost Modeling
-
-## Opertation model formulations contained in PowerSimulations
-
-- [Unit Commitment](https://en.wikipedia.org/wiki/Unit_commitment_problem_in_electrical_power_production)
-- [Economic Dispatch](https://en.wikipedia.org/wiki/Economic_dispatch)
-
+- Market Simulations
+  
 ## Installation
 
 ```julia

--- a/src/simulation/decision_model_simulation_results.jl
+++ b/src/simulation/decision_model_simulation_results.jl
@@ -267,10 +267,10 @@ function _read_results(
             (date_key, Matrix{Float64}(permutedims(inner_data.data)))
             for (date_key, inner_data) in result_data.data)
         converted_vals[result_key] = ResultsByTime{Matrix{Float64}, 1}(
-                        result_data.key,
-                        inner_converted,
-                        result_data.resolution,
-                        result_data.column_names)
+            result_data.key,
+            inner_converted,
+            result_data.resolution,
+            result_data.column_names)
     end
     return converted_vals
 end
@@ -524,12 +524,12 @@ function load_results!(
 
     function merge_results(store)
         for (key_type, new_items) in [
-                (ConstraintKey, duals),
-                (ParameterKey, parameters),
-                (VariableKey, variables),
-                (AuxVarKey, aux_variables),
-                (ExpressionKey, expressions),
-            ]
+            (ConstraintKey, duals),
+            (ParameterKey, parameters),
+            (VariableKey, variables),
+            (AuxVarKey, aux_variables),
+            (ExpressionKey, expressions),
+        ]
             new_keys = key_type[_deserialize_key(key_type, res, x...) for x in new_items]
             existing_results = get_cached_results(res, key_type)
             total_keys = union(collect(keys(existing_results)), new_keys)

--- a/src/simulation/decision_model_simulation_results.jl
+++ b/src/simulation/decision_model_simulation_results.jl
@@ -298,7 +298,6 @@ function _read_results(
         @debug "reading results from data store"
         vals = _get_store_value(res, result_keys, timestamps, store)
     end
-    @assert all(length.(values(vals)) .== length(timestamps))
     return vals
 end
 
@@ -573,7 +572,6 @@ function load_results!(
         merge_results(res.store)
     else
         simulation_store_path = joinpath(res.execution_path, "data_store")
-        println(simulation_store_path)
         open_store(HdfSimulationStore, simulation_store_path, "r") do store
             merge_results(store)
         end

--- a/src/simulation/emulation_model_simulation_results.jl
+++ b/src/simulation/emulation_model_simulation_results.jl
@@ -72,27 +72,6 @@ get_cached_parameters(res::SimulationProblemResults{EmulationModelSimulationResu
 get_cached_variables(res::SimulationProblemResults{EmulationModelSimulationResults}) =
     res.values.variables
 
-get_cached_results(
-    res::SimulationProblemResults{EmulationModelSimulationResults},
-    ::Type{<:AuxVarKey},
-) = get_cached_aux_variables(res)
-get_cached_results(
-    res::SimulationProblemResults{EmulationModelSimulationResults},
-    ::Type{<:ConstraintKey},
-) = get_cached_duals(res)
-get_cached_results(
-    res::SimulationProblemResults{EmulationModelSimulationResults},
-    ::Type{<:ExpressionKey},
-) = get_cached_expressions(res)
-get_cached_results(
-    res::SimulationProblemResults{EmulationModelSimulationResults},
-    ::Type{<:ParameterKey},
-) = get_cached_parameters(res)
-get_cached_results(
-    res::SimulationProblemResults{EmulationModelSimulationResults},
-    ::Type{<:VariableKey},
-) = get_cached_variables(res)
-
 function _list_containers(res::SimulationProblemResults)
     return (getfield(res.values, x) for x in get_container_fields(res))
 end
@@ -227,7 +206,7 @@ function _read_results(
     _validate_keys(existing_keys, result_keys)
     cached_results = Dict(
         k => v for
-        (k, v) in get_cached_results(res, typeof(first(result_keys))) if !isempty(v)
+        (k, v) in get_cached_results(res, eltype(result_keys)) if !isempty(v)
     )
     if isempty(setdiff(result_keys, keys(cached_results)))
         @debug "reading aux_variables from SimulationsResults"

--- a/src/simulation/emulation_model_simulation_results.jl
+++ b/src/simulation/emulation_model_simulation_results.jl
@@ -74,23 +74,23 @@ get_cached_variables(res::SimulationProblemResults{EmulationModelSimulationResul
 
 get_cached_results(
     res::SimulationProblemResults{EmulationModelSimulationResults},
-    ::AuxVarKey,
+    ::Type{<:AuxVarKey},
 ) = get_cached_aux_variables(res)
 get_cached_results(
     res::SimulationProblemResults{EmulationModelSimulationResults},
-    ::ConstraintKey,
+    ::Type{<:ConstraintKey},
 ) = get_cached_duals(res)
 get_cached_results(
     res::SimulationProblemResults{EmulationModelSimulationResults},
-    ::ExpressionKey,
+    ::Type{<:ExpressionKey},
 ) = get_cached_expressions(res)
 get_cached_results(
     res::SimulationProblemResults{EmulationModelSimulationResults},
-    ::ParameterKey,
+    ::Type{<:ParameterKey},
 ) = get_cached_parameters(res)
 get_cached_results(
     res::SimulationProblemResults{EmulationModelSimulationResults},
-    ::VariableKey,
+    ::Type{<:VariableKey},
 ) = get_cached_variables(res)
 
 function _list_containers(res::SimulationProblemResults)
@@ -226,7 +226,7 @@ function _read_results(
     existing_keys = list_result_keys(res, first(result_keys))
     _validate_keys(existing_keys, result_keys)
     cached_results = Dict(
-        k => v for (k, v) in get_cached_results(res, first(result_keys)) if !isempty(v)
+        k => v for (k, v) in get_cached_results(res, typeof(first(result_keys))) if !isempty(v)
     )
     if isempty(setdiff(result_keys, keys(cached_results)))
         @debug "reading aux_variables from SimulationsResults"
@@ -255,9 +255,8 @@ function read_results_with_keys(
 end
 
 """
-Load the simulation results into memory for repeated reads. Running this function twice
-overwrites the previously loaded results. This is useful when loading results from remote
-locations over network connections.
+Load the simulation results into memory for repeated reads. This is useful when loading
+results from remote locations over network connections.
 
 For each variable/parameter/dual, etc., each element must be the name encoded as a string,
 like `"ActivePowerVariable__ThermalStandard"`` or a Tuple with its constituent types, like

--- a/src/simulation/emulation_model_simulation_results.jl
+++ b/src/simulation/emulation_model_simulation_results.jl
@@ -226,7 +226,8 @@ function _read_results(
     existing_keys = list_result_keys(res, first(result_keys))
     _validate_keys(existing_keys, result_keys)
     cached_results = Dict(
-        k => v for (k, v) in get_cached_results(res, typeof(first(result_keys))) if !isempty(v)
+        k => v for
+        (k, v) in get_cached_results(res, typeof(first(result_keys))) if !isempty(v)
     )
     if isempty(setdiff(result_keys, keys(cached_results)))
         @debug "reading aux_variables from SimulationsResults"

--- a/src/simulation/realized_meta.jl
+++ b/src/simulation/realized_meta.jl
@@ -69,6 +69,8 @@ function _make_dataframe(
         row_end = row_index + last_id - first_id
         matrix[row_index:row_end, :] = array[first_id:last_id, :]
         row_index += last_id - first_id + 1
+        # Gracefully handle being given more results_by_time than we need
+        (row_index > num_rows) && break
     end
     df = DataFrames.DataFrame(matrix, collect(columns[1]); copycols = false)
     DataFrames.insertcols!(

--- a/src/simulation/realized_meta.jl
+++ b/src/simulation/realized_meta.jl
@@ -69,8 +69,6 @@ function _make_dataframe(
         row_end = row_index + last_id - first_id
         matrix[row_index:row_end, :] = array[first_id:last_id, :]
         row_index += last_id - first_id + 1
-        # Gracefully handle being given more results_by_time than we need
-        (row_index > num_rows) && break
     end
     df = DataFrames.DataFrame(matrix, collect(columns[1]); copycols = false)
     DataFrames.insertcols!(

--- a/src/simulation/simulation_problem_results.jl
+++ b/src/simulation/simulation_problem_results.jl
@@ -69,11 +69,41 @@ IS.get_timestamp(result::SimulationProblemResults) = result.results_timestamps
 get_interval(res::SimulationProblemResults) = res.timestamps.step
 IS.get_base_power(result::SimulationProblemResults) = result.base_power
 
+get_results_timestamps(result::SimulationProblemResults) = result.results_timestamps
+function set_results_timestamps!(
+    result::SimulationProblemResults,
+    results_timestamps::Vector{Dates.DateTime},
+)
+    result.results_timestamps = results_timestamps
+end
+
 list_result_keys(res::SimulationProblemResults, ::AuxVarKey) = list_aux_variable_keys(res)
 list_result_keys(res::SimulationProblemResults, ::ConstraintKey) = list_dual_keys(res)
 list_result_keys(res::SimulationProblemResults, ::ExpressionKey) = list_expression_keys(res)
 list_result_keys(res::SimulationProblemResults, ::ParameterKey) = list_parameter_keys(res)
 list_result_keys(res::SimulationProblemResults, ::VariableKey) = list_variable_keys(res)
+
+get_cached_results(res::SimulationProblemResults, ::Type{<:AuxVarKey}) =
+    get_cached_aux_variables(res)
+get_cached_results(res::SimulationProblemResults, ::Type{<:ConstraintKey}) =
+    get_cached_duals(res)
+get_cached_results(res::SimulationProblemResults, ::Type{<:ExpressionKey}) =
+    get_cached_expressions(res)
+get_cached_results(res::SimulationProblemResults, ::Type{<:ParameterKey}) =
+    get_cached_parameters(res)
+get_cached_results(res::SimulationProblemResults, ::Type{<:VariableKey}) =
+    get_cached_variables(res)
+get_cached_results(
+    res::SimulationProblemResults,
+    ::Type{<:OptimizationContainerKey} = OptimizationContainerKey,
+) =
+    merge(  # PERF: could be done lazily
+        get_cached_aux_variables(res),
+        get_cached_duals(res),
+        get_cached_expressions(res),
+        get_cached_parameters(res),
+        get_cached_variables(res),
+    )
 
 """
 Return an array of variable names (strings) that are available for reads.

--- a/test/test_simulation_results.jl
+++ b/test/test_simulation_results.jl
@@ -1,3 +1,26 @@
+# Read the actual data of a result to see what the timestamps are
+actual_timestamps(result) = result |> values |> first |> x->x.data |> keys |> collect
+
+# Test that a particular call to _read_results reads from outside the cache; pass through the results
+macro test_no_cache(expr)
+    :(@test_logs(
+        match_mode = :any,
+        (:debug, r"reading results from data store"),
+        min_level=Logging.Debug,
+        $(esc(expr))))
+end
+@test_no_cache((@debug "reading results from data store"; @debug "msg 2"))
+
+# Test that a particular call to _read_results reads from the cache; pass through the results
+macro test_yes_cache(expr)
+    :(@test_logs(
+        match_mode = :any,
+        (:debug, r"reading results from SimulationsResults cache"),
+        min_level=Logging.Debug,
+        $(esc(expr))))
+end
+@test_yes_cache((@debug "reading results from SimulationsResults cache"; @debug "msg 2"))
+
 ED_EXPECTED_VARS = [
     "ActivePowerVariable__HydroEnergyReservoir",
     "ActivePowerVariable__RenewableDispatch",
@@ -497,6 +520,56 @@ function test_decision_problem_results_values(
             "",
         )].data,
     )
+
+    # Inspired by https://github.com/NREL-Sienna/PowerSimulations.jl/issues/1072
+    @testset "Test cache behavior" begin
+        myres = deepcopy(results_ed)
+        initial_time = DateTime("2024-01-01T00:00:00")
+        timestamps = PSI._process_timestamps(myres, initial_time, 3)
+        variable_tuple = (ActivePowerVariable, ThermalStandard)
+        variable_key = PSI.VariableKey(variable_tuple...)
+
+        empty!(myres)
+        @test isempty(PSI.get_cached_variables(myres))
+        
+        # With nothing cached, all reads should be from outside the cache
+        read = @test_no_cache PSI._read_results(myres, [variable_key], timestamps, nothing)
+        @test actual_timestamps(read) == timestamps
+        
+        # With 2 result windows cached, reading 2 windows should come from cache and reading 3 should come from outside
+        load_results!(myres, 2; initial_time = initial_time, variables = [variable_tuple])
+        @test haskey(PSI.get_cached_variables(myres), variable_key)
+        read = @test_yes_cache PSI._read_results(myres, [variable_key], timestamps[1:2], nothing)
+        @test actual_timestamps(read) == timestamps[1:2]
+        read = @test_no_cache PSI._read_results(myres, [variable_key], timestamps, nothing)
+        @test actual_timestamps(read) == timestamps
+
+        # With 3 result windows cached, reading 2 and 3 windows should both come from cache
+        load_results!(myres, 3; initial_time = initial_time, variables = [variable_tuple])
+        read = @test_yes_cache PSI._read_results(myres, [variable_key], timestamps[1:2], nothing)
+        @test isempty(setdiff(timestamps[1:2], actual_timestamps(read)))  # Allow the timestamps actually read to be a superset of those requested
+        read = @test_yes_cache PSI._read_results(myres, [variable_key], timestamps, nothing)
+        @test actual_timestamps(read) == timestamps
+
+        # Caching an additional variable should incur an additional read but not evict the old variable
+        @test_no_cache load_results!(myres, 3; initial_time = initial_time, variables = [(ActivePowerVariable, RenewableDispatch)])
+        @test haskey(PSI.get_cached_variables(myres), variable_key)
+        @test haskey(PSI.get_cached_variables(myres), PSI.VariableKey(ActivePowerVariable, RenewableDispatch))
+
+        # Reset back down to 2 windows
+        empty!(myres)
+        @test isempty(PSI.get_cached_variables(myres))
+        @test_no_cache load_results!(myres, 2; initial_time = initial_time, variables = [variable_tuple])
+
+        # Loading a subset of what has already been loaded should not incur additional reads from outside the cache
+        @test_yes_cache load_results!(myres, 2; initial_time = initial_time, variables = [variable_tuple])
+        @test_yes_cache load_results!(myres, 1; initial_time = initial_time, variables = [variable_tuple])
+        # But loading a superset should
+        @test_no_cache load_results!(myres, 3; initial_time = initial_time, variables = [variable_tuple])
+
+        empty!(myres)
+        @test isempty(PSI.get_cached_variables(myres))
+    end
 end
 
 function test_decision_problem_results(


### PR DESCRIPTION
This fixes #1070 and #1072.

## On #1070:
There is some inherent overhead to creating large arrays that cannot be avoided, but now that we use the cache the time for repeated calls to `_read_results(Matrix{Float64}...` on my big dataset has decreased 30x from 0.09s to 0.003s:
```julia
julia> @time results_mat = PSI._read_results(Matrix{Float64}, res, variables, timestamps, nothing)
  0.003551 seconds (340 allocations: 7.419 MiB)
```

This is much better and closes the issue but is still unnecessarily heavy-handed for my PowerAnalytics component-wise reads, so later I may seek to add an option to PowerSimulations to perform `read_results_with_keys` for only one component at a time.

## On #1072:
Ended up being more refactoring than initially planned, but the upshot is that for the `DecisionModelSimulationResults` method of `load_results!` the documentation now precisely describes what happens, what happens is good, the bug preventing it from loading more timestamps is gone, some code duplication has been removed, and there are lots more tests. I did not significantly edit the `EmulationModelSimulationResults` method of `load_results!`; it appears to have a significantly different interface that does not even take in time steps.

```julia
# after the setup detailed in bug #1072
julia> PSI._read_results(res, variable_keys, timestamps, nothing) |> values |> first |> x->x.data |> keys |> collect
7-element Vector{DateTime}:
 2035-01-01T00:00:00
 2035-01-02T00:00:00
 2035-01-03T00:00:00
 2035-01-04T00:00:00
 2035-01-05T00:00:00
 2035-01-06T00:00:00
 2035-01-07T00:00:00
```