### PR TITLE
Refactor store selection process

### DIFF
--- a/src/simulation/decision_model_simulation_results.jl
+++ b/src/simulation/decision_model_simulation_results.jl
@@ -263,10 +263,7 @@ function _read_results(
     isempty(result_keys) &&
         return Dict{OptimizationContainerKey, ResultsByTime{DenseAxisArray{Float64, 2}}}()
 
-    if store === nothing && res.store !== nothing
-        # In this case we have an InMemorySimulationStore.
-        store = res.store
-    end
+    _store = try_resolve_store(store, res.store)
     existing_keys = list_result_keys(res, first(result_keys))
     _validate_keys(existing_keys, result_keys)
     cached_results = get_cached_results(res, eltype(result_keys))
@@ -287,7 +284,7 @@ function _read_results(
         return filtered_vals
     else
         @debug "reading results from data store"  # NOTE tests match on this
-        vals = _get_store_value(res, result_keys, timestamps, store)
+        vals = _get_store_value(res, result_keys, timestamps, _store)
     end
     return vals
 end

--- a/src/simulation/emulation_model_simulation_results.jl
+++ b/src/simulation/emulation_model_simulation_results.jl
@@ -197,11 +197,7 @@ function _read_results(
     len = nothing,
 )
     isempty(result_keys) && return Dict{OptimizationContainerKey, DataFrames.DataFrame}()
-    if store === nothing && res.store !== nothing
-        # In this case we have an InMemorySimulationStore.
-        store = res.store
-    end
-
+    _store = try_resolve_store(store, res.store)
     existing_keys = list_result_keys(res, first(result_keys))
     _validate_keys(existing_keys, result_keys)
     cached_results = Dict(
@@ -217,7 +213,7 @@ function _read_results(
             _get_store_value(
                 res,
                 result_keys,
-                store;
+                _store;
                 start_time = start_time,
                 len = len,
             )

--- a/src/simulation/simulation_problem_results.jl
+++ b/src/simulation/simulation_problem_results.jl
@@ -745,3 +745,9 @@ function export_optimizer_stats(
         throw(error("writing optimizer stats only supports csv or json formats"))
     end
 end
+
+# Chooses the user-passed store or results store for reading values. Either could be
+# something or nothing. If both are nothing, we must open the HDF5 store.
+try_resolve_store(user::SimulationStore, results::Union{Nothing, SimulationStore}) = user
+try_resolve_store(user::Nothing, results::SimulationStore) = results
+try_resolve_store(user::Nothing, results::Nothing) = nothing


### PR DESCRIPTION
This PR attempts to address the concerns in #1018. I don’t think that issue is valid. There is no way to have a consistent interface with the in-memory store and the HDF5 store. The HDF5 store must be opened with a file path:
```
open_store(HdfSimulationStore, simulation_store_path, "r") do store
    # do stuff
end
```
The in-memory store is already open. What would it look like?
```
open(InMemorySimulationStore, _, “r”, store) do store
    # do stuff
end
```
It’s a different interface no matter how you do it.

There is a concern underlying the issue above that we have a code block that makes a non-straightforward inference about the type of the store. This addresses that.

There was another concern at https://github.com/NREL-Sienna/PowerSimulations.jl/pull/1073/files#r1512052861 which says that we should not have functions that take `Union{Nothing, <:SimulationStore}`. I don’t think this is a problem. We have code paths where the store is not passed (defaults to nothing and then is opened) and others where the store is passed. 