### PR TITLE
Further results cache optimizations to support PowerAnalytics

### DIFF
--- a/src/simulation/decision_model_simulation_results.jl
+++ b/src/simulation/decision_model_simulation_results.jl
@@ -508,34 +508,24 @@ function load_results!(
     parameters = Vector{Tuple}(),
     aux_variables = Vector{Tuple}(),
     expressions = Vector{Tuple}(),
+    store::Union{Nothing, <:SimulationStore} = nothing,
 )
     initial_time = initial_time === nothing ? first(get_timestamps(res)) : initial_time
     count = max(count, length(get_results_timestamps(res)))
     new_timestamps = _process_timestamps(res, initial_time, count)
 
-    function merge_results(store)
-        for (key_type, new_items) in [
-            (ConstraintKey, duals),
-            (ParameterKey, parameters),
-            (VariableKey, variables),
-            (AuxVarKey, aux_variables),
-            (ExpressionKey, expressions),
-        ]
-            new_keys = key_type[_deserialize_key(key_type, res, x...) for x in new_items]
-            existing_results = get_cached_results(res, key_type)
-            total_keys = union(collect(keys(existing_results)), new_keys)
-            # _read_results checks the cache to eliminate unnecessary re-reads
-            merge!(existing_results, _read_results(res, total_keys, new_timestamps, store))
-        end
-    end
-
-    if res.store isa InMemorySimulationStore
-        merge_results(res.store)
-    else
-        simulation_store_path = joinpath(res.execution_path, "data_store")
-        open_store(HdfSimulationStore, simulation_store_path, "r") do store
-            merge_results(store)
-        end
+    for (key_type, new_items) in [
+        (ConstraintKey, duals),
+        (ParameterKey, parameters),
+        (VariableKey, variables),
+        (AuxVarKey, aux_variables),
+        (ExpressionKey, expressions),
+    ]
+        new_keys = key_type[_deserialize_key(key_type, res, x...) for x in new_items]
+        existing_results = get_cached_results(res, key_type)
+        total_keys = union(collect(keys(existing_results)), new_keys)
+        # _read_results checks the cache to eliminate unnecessary re-reads
+        merge!(existing_results, _read_results(res, total_keys, new_timestamps, store))
     end
     set_results_timestamps!(res, new_timestamps)
 

--- a/test/test_simulation_results.jl
+++ b/test/test_simulation_results.jl
@@ -637,6 +637,40 @@ function test_decision_problem_results_values(
         empty!(myres)
         @test isempty(PSI.get_cached_variables(myres))
     end
+
+    @testset "Test read_results_with_keys" begin
+        myres = deepcopy(results_ed)
+        initial_time = DateTime("2024-01-01T00:00:00")
+        timestamps = PSI._process_timestamps(myres, initial_time, 3)
+        result_keys = [PSI.VariableKey(ActivePowerVariable, ThermalStandard)]
+
+        res1 = PSI.read_results_with_keys(myres, result_keys)
+        @test Set(keys(res1)) == Set(result_keys)
+        res1_df = res1[first(result_keys)]
+        @test size(res1_df) == (576, 6)
+        @test names(res1_df) ==
+              ["DateTime", "Solitude", "Park City", "Alta", "Brighton", "Sundance"]
+        @test first(eltype.(eachcol(res1_df))) === DateTime
+
+        res2 =
+            PSI.read_results_with_keys(myres, result_keys; cols = ["Park City", "Brighton"])
+        @test Set(keys(res2)) == Set(result_keys)
+        res2_df = res2[first(result_keys)]
+        @test size(res2_df) == (576, 3)
+        @test names(res2_df) ==
+              ["DateTime", "Park City", "Brighton"]
+        @test first(eltype.(eachcol(res2_df))) === DateTime
+
+        res3_df =
+            PSI.read_results_with_keys(myres, result_keys; start_time = timestamps[2])[first(
+                result_keys,
+            )]
+        @test res3_df[1, "DateTime"] == timestamps[2]
+
+        res4_df =
+            PSI.read_results_with_keys(myres, result_keys; len = 2)[first(result_keys)]
+        @test size(res4_df) == (2, 6)
+    end
 end
 
 function test_decision_problem_results(


### PR DESCRIPTION
Two main things here:

1. `load_results!` was opening a store even if all the requested results were already cached; opening the store is now left to `_read_results` after it decides whether it needs to do so.
2. `read_results_with_keys` is slowish even if the results are already cached because a lot of data has to be converted to DataFrame. Now there is an optional kwarg to request a certain list of columns and only those will be converted, resulting in much (~1000x on large datasets) less memory usage and much faster call times.

The result is that `load_results!` and `read_results_with_keys` can be called thousands of times in a tight loop as PowerAnalytics iterates over components and it's not horrendously inefficient (just a few seconds total for large datasets). Leaving as draft in case I identify more small optimizations to add.