### PR TITLE
Enable parallel tests by moving includes to one file

### DIFF
--- a/test/includes.jl
+++ b/test/includes.jl
@@ -1,0 +1,46 @@
+# SIIP Packages
+using PowerSimulations
+using PowerSystems
+using PowerSystemCaseBuilder
+using InfrastructureSystems
+using PowerNetworkMatrices
+using HydroPowerSimulations
+import PowerSystemCaseBuilder: PSITestSystems
+using PowerNetworkMatrices
+using StorageSystemsSimulations
+
+# Test Packages
+using Test
+using Logging
+
+# Dependencies for testing
+using PowerModels
+using DataFrames
+using Dates
+using JuMP
+using TimeSeries
+using CSV
+import JSON3
+using DataFrames
+using DataStructures
+import UUIDs
+using Random
+import Serialization
+
+const PM = PowerModels
+const PSY = PowerSystems
+const PSI = PowerSimulations
+const PSB = PowerSystemCaseBuilder
+const PNM = PowerNetworkMatrices
+
+const IS = InfrastructureSystems
+const BASE_DIR = string(dirname(dirname(pathof(PowerSimulations))))
+const DATA_DIR = joinpath(BASE_DIR, "test/test_data")
+
+include("test_utils/common_operation_model.jl")
+include("test_utils/model_checks.jl")
+include("test_utils/mock_operation_models.jl")
+include("test_utils/solver_definitions.jl")
+include("test_utils/operations_problem_templates.jl")
+
+ENV["RUNNING_PSI_TESTS"] = "true"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,31 +1,4 @@
-# SIIP Packages
-using PowerSimulations
-using PowerSystems
-using PowerSystemCaseBuilder
-using InfrastructureSystems
-using PowerNetworkMatrices
-using HydroPowerSimulations
-import PowerSystemCaseBuilder: PSITestSystems
-using PowerNetworkMatrices
-using StorageSystemsSimulations
-
-# Test Packages
-using Test
-using Logging
-
-# Dependencies for testing
-using PowerModels
-using DataFrames
-using Dates
-using JuMP
-using TimeSeries
-using CSV
-import JSON3
-using DataFrames
-using DataStructures
-import UUIDs
-using Random
-import Serialization
+include("includes.jl")
 
 # Code Quality Tests
 import Aqua
@@ -33,25 +6,7 @@ Aqua.test_unbound_args(PowerSimulations)
 Aqua.test_undefined_exports(PowerSimulations)
 Aqua.test_ambiguities(PowerSimulations)
 
-const PM = PowerModels
-const PSY = PowerSystems
-const PSI = PowerSimulations
-const PSB = PowerSystemCaseBuilder
-const PNM = PowerNetworkMatrices
-
-const IS = InfrastructureSystems
-const BASE_DIR = string(dirname(dirname(pathof(PowerSimulations))))
-const DATA_DIR = joinpath(BASE_DIR, "test/test_data")
-
-include("test_utils/common_operation_model.jl")
-include("test_utils/model_checks.jl")
-include("test_utils/mock_operation_models.jl")
-include("test_utils/solver_definitions.jl")
-include("test_utils/operations_problem_templates.jl")
-
 const LOG_FILE = "power-simulations-test.log"
-
-ENV["RUNNING_PSI_TESTS"] = "true"
 
 const DISABLED_TEST_FILES = [
     # "test_basic_model_structs.jl",


### PR DESCRIPTION
This will allow parallel testing with SiennaIntegrationTests. It will also allow people to test a single file by running
```
julia> include(“test/includes.jl”)
julia> include(“test/test_X.jl”)
```