### PR TITLE
Merge fixes

### DIFF
--- a/src/devices_models/device_constructors/branch_constructor.jl
+++ b/src/devices_models/device_constructors/branch_constructor.jl
@@ -13,7 +13,7 @@ function construct_device!(
     if has_subnetworks(network_model)
         devices = get_available_components(model, sys)
 
-        if get_use_slacks(device_model)
+        if get_use_slacks(model)
             add_variables!(
                 container,
                 FlowActivePowerSlackUpperBound,
@@ -84,7 +84,7 @@ function construct_device!(
         NetworkModel{AreaBalancePowerModel},
     },
 ) where {T <: PSY.ACBranch}
-    if get_use_slacks(device_model)
+    if get_use_slacks(model)
         throw(ArgumentError("StaticBranchBounds is not compatible with the use of slacks"))
     end
     if has_subnetworks(network_model)
@@ -201,7 +201,7 @@ function construct_device!(
     device_model::DeviceModel{T, StaticBranch},
     network_model::NetworkModel{<:PM.AbstractActivePowerModel},
 ) where {T <: PSY.ACBranch}
-    devices = get_available_components(model, sys)
+    devices = get_available_components(device_model, sys)
     if get_use_slacks(device_model)
         add_variables!(
             container,
@@ -218,7 +218,7 @@ function construct_device!(
     end
     add_feedforward_arguments!(container, device_model, devices)
 
-    add_feedforward_arguments!(container, model, devices)
+    add_feedforward_arguments!(container, device_model, devices)
 end
 
 # For DC Power only. Implements constraints
@@ -231,7 +231,7 @@ function construct_device!(
 ) where {T <: PSY.ACBranch, U <: PM.AbstractActivePowerModel}
     @debug "construct_device" _group = LOG_GROUP_BRANCH_CONSTRUCTIONS
 
-    devices = get_available_components(model, sys)
+    devices = get_available_components(device_model, sys)
     add_constraints!(container, RateLimitConstraint, devices, device_model, network_model)
     add_feedforward_constraints!(container, device_model, devices)
     objective_function!(container, devices, device_model, U)
@@ -248,7 +248,7 @@ function construct_device!(
     network_model::NetworkModel{PTDFPowerModel},
 ) where {T <: PSY.ACBranch}
     devices = get_available_components(model, sys)
-    if get_use_slacks(device_model)
+    if get_use_slacks(model)
         add_variables!(
             container,
             FlowActivePowerSlackUpperBound,
@@ -283,10 +283,10 @@ function construct_device!(
     network_model::NetworkModel{PTDFPowerModel},
 ) where {T <: PSY.ACBranch}
     devices = get_available_components(model, sys)
-    add_constraints!(container, NetworkFlowConstraint, devices, device_model, network_model)
-    add_constraints!(container, RateLimitConstraint, devices, device_model, network_model)
-    objective_function!(container, devices, device_model, PTDFPowerModel)
-    add_constraint_dual!(container, sys, device_model)
+    add_constraints!(container, NetworkFlowConstraint, devices, model, network_model)
+    add_constraints!(container, RateLimitConstraint, devices, model, network_model)
+    objective_function!(container, devices, model, PTDFPowerModel)
+    add_constraint_dual!(container, sys, model)
     return
 end
 
@@ -299,7 +299,7 @@ function construct_device!(
 ) where {T <: PSY.ACBranch}
     devices = get_available_components(model, sys)
 
-    if get_use_slacks(device_model)
+    if get_use_slacks(model)
         throw(ArgumentError("StaticBranchBounds is not compatible with the use of slacks"))
     end
 
@@ -375,8 +375,7 @@ function construct_device!(
     device_model::DeviceModel{T, StaticBranch},
     network_model::NetworkModel{<:PM.AbstractPowerModel},
 ) where {T <: PSY.ACBranch}
-    devices =
-        get_available_components(T, sys, get_attribute(device_model, "filter_function"))
+    devices = get_available_components(device_model, sys)
 
     if get_use_slacks(device_model)
         # Only one slack is needed for this formulations in AC
@@ -398,7 +397,7 @@ function construct_device!(
     device_model::DeviceModel{T, StaticBranch},
     network_model::NetworkModel{U},
 ) where {T <: PSY.ACBranch, U <: PM.AbstractPowerModel}
-    devices = get_available_components(model, sys)
+    devices = get_available_components(device_model, sys)
     add_constraints!(
         container,
         RateLimitConstraintFromTo,
@@ -442,7 +441,7 @@ function construct_device!(
     device_model::DeviceModel{T, StaticBranchBounds},
     network_model::NetworkModel{<:PM.AbstractPowerModel},
 ) where {T <: PSY.ACBranch}
-    devices = get_available_components(model, sys)
+    devices = get_available_components(device_model, sys)
     branch_rate_bounds!(container, devices, device_model, network_model)
     add_constraints!(
         container,
@@ -469,7 +468,7 @@ function construct_device!(
     device_model::DeviceModel{T, StaticBranchBounds},
     network_model::NetworkModel{<:PM.AbstractActivePowerModel},
 ) where {T <: PSY.ACBranch}
-    devices = get_available_components(model, sys)
+    devices = get_available_components(device_model, sys)
     branch_rate_bounds!(container, devices, device_model, network_model)
     add_constraint_dual!(container, sys, device_model)
     return

--- a/src/devices_models/devices/thermal_generation.jl
+++ b/src/devices_models/devices/thermal_generation.jl
@@ -125,7 +125,7 @@ function no_load_cost(cost::PSY.QuadraticFunctionData, ::OnVariable, d::PSY.Ther
         [PSY.get_quadratic_term(cost), PSY.get_proportional_term(cost), PSY.get_constant_term(cost)],
         [min_power^2, min_power, 1]
     )
-    return evaluated * PSY.get_base_power(d)
+    return evaluated * PSY.get_system_base_power(d)
 end
 
 #! format: on

--- a/src/simulation/hdf_simulation_store.jl
+++ b/src/simulation/hdf_simulation_store.jl
@@ -653,32 +653,6 @@ function write_result!(
     return
 end
 
-function write_result!(
-    store::HdfSimulationStore,
-    model_name::Symbol,
-    key::OptimizationContainerKey,
-    index::EmulationModelIndexType,
-    simulation_time::Dates.DateTime,
-    data::DenseAxisArray{Float64, 2},
-)
-    data_array = Array{Float64, 3}(undef, size(data)[1], size(data)[2], 1)
-    data_array[:, :, 1] = data
-    write_result!(store, model_name, key, index, simulation_time, data_array)
-    return
-end
-
-function write_result!(
-    store::HdfSimulationStore,
-    model_name::Symbol,
-    key::OptimizationContainerKey,
-    index::EmulationModelIndexType,
-    simulation_time::Dates.DateTime,
-    data::DenseAxisArray{Float64, 1},
-)
-    write_result!(store, model_name, key, index, simulation_time, to_matrix(data))
-    return
-end
-
 function serialize_system!(store::HdfSimulationStore, sys::PSY.System)
     root = store.file[HDF_SIMULATION_ROOT_PATH]
     systems_group = _get_group_or_create(root, "systems")

--- a/src/simulation/simulation.jl
+++ b/src/simulation/simulation.jl
@@ -326,7 +326,6 @@ function _build_single_model_for_simulation(
     sim::Simulation,
     model_number::Int,
 )
-    @error("Building problem $(get_name(model)) $(Threads.threadid())")
     initial_time = get_initial_time(sim)
     set_initial_time!(model, initial_time)
     output_dir = joinpath(get_models_dir(sim), string(get_name(model)))

--- a/test/test_device_thermal_generation_constructors.jl
+++ b/test/test_device_thermal_generation_constructors.jl
@@ -826,7 +826,7 @@ end
     min_limit = PSY.get_active_power_limits(comp).min
     @test isapprox(
         PSI.no_load_cost(
-            VariableCost(5.0),
+            PSY.LinearFunctionData(5.0),
             OnVariable(),
             comp,
             ThermalBasicUnitCommitment(),

--- a/test/test_device_thermal_generation_constructors.jl
+++ b/test/test_device_thermal_generation_constructors.jl
@@ -835,7 +835,7 @@ end
     )
     @test isapprox(
         PSI.no_load_cost(
-            VariableCost((3.0, 5.0)),
+            QuadraticFunctionData(3.0, 5.0, 0.0),
             OnVariable(),
             comp,
             ThermalBasicUnitCommitment(),


### PR DESCRIPTION
Perhaps there was a mis-merge recently. I fixed the variable names in branch_constructor.jl. There was another error caused by a merge from main into psy4.

There is still a breakage in the psy4 branch.

```
┌ Error: simulation failed
│   exception =
│    MethodError: no method matching write_result!(::PowerSimulations.HdfSimulationStore, ::Symbol, ::PowerSimulations.ConstraintKey{CopperPlateBalanceConstraint, System}, ::Int64, ::DateTime, ::Matrix{Float64})
```
```
│    Stacktrace:
│      [1] write_result!(store::PowerSimulations.HdfSimulationStore, model_name::Symbol, key::PowerSimulations.ConstraintKey{CopperPlateBalanceConstraint, System}, index::Int64, simulation_time::DateTime, data::JuMP.Containers.DenseAxisArray{Float64, 1, Tuple{Vector{String}}, Tuple{JuMP.Containers._AxisLookup{Dict{String, Int64}}}})
│        @ PowerSimulations ~/repos/sienna/PowerSimulations.jl/src/simulation/hdf_simulation_store.jl:678
```