### PR TITLE
Ignore known-benign extraneous files in simulation results

### DIFF
--- a/src/core/definitions.jl
+++ b/src/core/definitions.jl
@@ -90,6 +90,14 @@ const KNOWN_SIMULATION_PATHS = [
     "simulation_files",
     "simulation_partitions",
 ]
+"If the name of an extraneous file that appears in simulation results matches one of these regexes, it is safe to ignore"
+const IGNORABLE_FILES = [
+    r"^\.DS_Store$",
+    r"^\.Trashes$",
+    r"^\.Trash-.*$",
+    r"^\.nfs.*$",
+    r"^[Dd]esktop.ini$",
+]
 const RESULTS_DIR = "results"
 
 # Enums

--- a/src/simulation/simulation_results.jl
+++ b/src/simulation/simulation_results.jl
@@ -1,6 +1,7 @@
 function check_folder_integrity(folder::String)
     folder_files = readdir(folder)
     alien_files = setdiff(folder_files, KNOWN_SIMULATION_PATHS)
+    alien_files = filter(x -> !any(occursin.(IGNORABLE_FILES, x)), alien_files)
     if isempty(alien_files)
         return true
     else


### PR DESCRIPTION
I got tired of these warnings:
<img width="1087" alt="Screenshot 2024-06-21 at 4 09 25 PM" src="https://github.com/NREL-Sienna/PowerSimulations.jl/assets/23368820/5c56b9d4-69d5-457b-9a8c-bf9c18265399">
and we should aim to eliminate warnings that cry wolf. Here I add a list of regexes similar to a `.gitignore` that represent files we know it is safe to ignore.

---
Happy to cherry-pick and set the base branch to something else, this was the most standard-looking branch I could find that actually compiles with PSY4.