### PR TITLE
Make minimal tweaks for backwards compatibility

### DIFF
--- a/src/core/definitions.jl
+++ b/src/core/definitions.jl
@@ -113,6 +113,10 @@ for enum in ENUMS
     end
 end
 
+# Special cases for backwards compatibility
+ENUM_MAPPINGS[RunStatus]["ready"] = RunStatus.INITIALIZED
+ENUM_MAPPINGS[RunStatus]["successful"] = RunStatus.SUCCESSFULLY_FINALIZED
+
 """
 Get the enum value for the string. Case insensitive.
 """

--- a/src/simulation/hdf_simulation_store.jl
+++ b/src/simulation/hdf_simulation_store.jl
@@ -740,7 +740,13 @@ function _deserialize_attributes!(store::HdfSimulationStore)
     empty!(get_dm_data(store))
     for model in HDF5.read(HDF5.attributes(group)["problem_order"])
         problem_group = store.file["simulation/decision_models/$model"]
-        horizon_count = HDF5.read(HDF5.attributes(problem_group)["horizon_count"])
+        # Fall back on old key for backwards compatibility
+        horizon_count = HDF5.read(
+            if haskey(HDF5.attributes(problem_group), "horizon_count")
+                HDF5.attributes(problem_group)["horizon_count"]
+            else
+                HDF5.attributes(problem_group)["horizon"]
+            end)
         model_name = Symbol(model)
         store.params.decision_models_params[model_name] = ModelStoreParams(
             HDF5.read(HDF5.attributes(problem_group)["num_executions"]),
@@ -785,7 +791,13 @@ function _deserialize_attributes!(store::HdfSimulationStore)
     end
 
     em_group = _get_emulation_model_path(store)
-    horizon_count = HDF5.read(HDF5.attributes(em_group)["horizon_count"])
+    # Fall back on old key for backwards compatibility
+    horizon_count = HDF5.read(
+        if haskey(HDF5.attributes(em_group), "horizon_count")
+            HDF5.attributes(em_group)["horizon_count"]
+        else
+            HDF5.attributes(em_group)["horizon"]
+        end)
     model_name = Symbol(HDF5.read(HDF5.attributes(em_group)["name"]))
     resolution = Dates.Millisecond(HDF5.read(HDF5.attributes(em_group)["resolution_ms"]))
     store.params.emulation_model_params[model_name] = ModelStoreParams(


### PR DESCRIPTION
We don't guarantee backwards compatibility, but when it's this easy it seems like we might as well. With just these changes I was able to load some old simulation results I wanted.

---
As in https://github.com/NREL-Sienna/PowerSimulations.jl/pull/1117, happy to cherry-pick and set the base branch to something else, this was the most standard-looking branch I could find that actually compiles with PSY4.