### PR TITLE
Add `ComponentSelector` feature: PSI portion

### DIFF
--- a/src/PowerSimulations.jl
+++ b/src/PowerSimulations.jl
@@ -398,7 +398,8 @@ import InfrastructureSystems.Optimization: read_results_with_keys, deserialize_k
 
 # PowerSystems imports
 import PowerSystems:
-    get_components, get_available_components, get_component
+    get_components, get_available_components, get_component,
+    get_groups, get_available_groups
 
 export get_name
 export get_model_base_power

--- a/src/PowerSimulations.jl
+++ b/src/PowerSimulations.jl
@@ -396,6 +396,10 @@ import InfrastructureSystems.Optimization: read_results_with_keys, deserialize_k
 
 # IS.Optimization imports that stay private, may or may not be additional methods in PowerSimulations
 
+# PowerSystems imports
+import PowerSystems:
+    get_components, get_available_components, get_component
+
 export get_name
 export get_model_base_power
 export get_optimizer_stats

--- a/src/PowerSimulations.jl
+++ b/src/PowerSimulations.jl
@@ -393,12 +393,13 @@ import InfrastructureSystems.Optimization:
 import InfrastructureSystems.Optimization: read_results_with_keys, deserialize_key,
     encode_key_as_string, encode_keys_as_strings, should_write_resulting_value,
     convert_result_to_natural_units, to_matrix, get_store_container_type
+import InfrastructureSystems.Optimization: get_source_data
 
 # IS.Optimization imports that stay private, may or may not be additional methods in PowerSimulations
 
 # PowerSystems imports
 import PowerSystems:
-    get_components, get_available_components, get_component,
+    get_components, get_component, get_available_components, get_available_component,
     get_groups, get_available_groups
 
 export get_name
@@ -535,6 +536,7 @@ include("simulation/simulation_store_params.jl")
 include("simulation/hdf_simulation_store.jl")
 include("simulation/in_memory_simulation_store.jl")
 include("simulation/simulation_problem_results.jl")
+include("simulation/get_components_interface.jl")
 include("simulation/decision_model_simulation_results.jl")
 include("simulation/emulation_model_simulation_results.jl")
 include("simulation/realized_meta.jl")

--- a/src/simulation/get_components_interface.jl
+++ b/src/simulation/get_components_interface.jl
@@ -1,0 +1,53 @@
+# Analogous to `src/get_components_interface.jl` in PowerSystems.jl, see comments there.
+
+# get_components
+"""
+Calling `get_components` on a `Results` is the same as calling
+[`get_available_components`](@ref) on the system attached to the results.
+"""
+PSY.get_components(
+    ::Type{T},
+    res::IS.Results;
+    subsystem_name = nothing,
+) where {T <: IS.InfrastructureSystemsComponent} =
+    IS.get_components(T, res; subsystem_name = subsystem_name)
+
+PSY.get_components(res::IS.Results, attribute::IS.SupplementalAttribute) =
+    IS.get_components(res, attribute)
+
+PSY.get_components(
+    filter_func::Function,
+    ::Type{T},
+    res::IS.Results;
+    subsystem_name = nothing,
+) where {T <: IS.InfrastructureSystemsComponent} =
+    IS.get_components(filter_func, T, res; subsystem_name = subsystem_name)
+
+PSY.get_components(selector::IS.ComponentSelector, res::IS.Results; kwargs...) =
+    IS.get_components(selector, res; kwargs...)
+
+# get_component
+"""
+Calling `get_component` on a `Results` is the same as calling
+[`get_available_component`](@ref) on the system attached to the results.
+"""
+PSY.get_component(res::IS.Results, uuid::Base.UUID) = IS.get_component(res, uuid)
+PSY.get_component(res::IS.Results, uuid::String) = IS.get_component(res, uuid)
+
+PSY.get_component(
+    ::Type{T},
+    res::IS.Results,
+    name::AbstractString,
+) where {T <: IS.InfrastructureSystemsComponent} =
+    IS.get_component(T, res, name)
+
+PSY.get_component(selector::IS.SingularComponentSelector, res::IS.Results; kwargs...) =
+    IS.get_component(selector, res; kwargs...)
+
+# get_groups
+"""
+Calling `get_groups` on a `Results` is the same as calling [`get_available_groups`](@ref) on
+the system attached to the results.
+"""
+PSY.get_groups(selector::IS.ComponentSelector, res::IS.Results; kwargs...) =
+    IS.get_groups(selector, res; kwargs...)

--- a/src/simulation/get_components_interface.jl
+++ b/src/simulation/get_components_interface.jl
@@ -3,7 +3,7 @@
 # get_components
 """
 Calling `get_components` on a `Results` is the same as calling
-[`get_available_components`](@ref) on the system attached to the results.
+[`get_available_components`] on the system attached to the results.
 """
 PSY.get_components(
     ::Type{T},
@@ -36,7 +36,7 @@ PSY.get_components(selector::IS.ComponentSelector, res::IS.Results) =
 # get_component
 """
 Calling `get_component` on a `Results` is the same as calling
-[`get_available_component`](@ref) on the system attached to the results.
+[`get_available_component`] on the system attached to the results.
 """
 PSY.get_component(res::IS.Results, uuid::Base.UUID) = IS.get_component(res, uuid)
 PSY.get_component(res::IS.Results, uuid::String) = IS.get_component(res, uuid)
@@ -60,7 +60,7 @@ PSY.get_component(selector::IS.SingularComponentSelector, res::IS.Results) =
 
 # get_groups
 """
-Calling `get_groups` on a `Results` is the same as calling [`get_available_groups`](@ref) on
+Calling `get_groups` on a `Results` is the same as calling [`get_available_groups`] on
 the system attached to the results.
 """
 PSY.get_groups(

--- a/src/simulation/get_components_interface.jl
+++ b/src/simulation/get_components_interface.jl
@@ -23,8 +23,15 @@ PSY.get_components(
 ) where {T <: IS.InfrastructureSystemsComponent} =
     IS.get_components(filter_func, T, res; subsystem_name = subsystem_name)
 
-PSY.get_components(selector::IS.ComponentSelector, res::IS.Results; kwargs...) =
-    IS.get_components(selector, res; kwargs...)
+PSY.get_components(
+    scope_limiter::Union{Function, Nothing},
+    selector::IS.ComponentSelector,
+    res::IS.Results,
+) =
+    IS.get_components(scope_limiter, selector, res)
+
+PSY.get_components(selector::IS.ComponentSelector, res::IS.Results) =
+    IS.get_components(selector, res)
 
 # get_component
 """
@@ -41,13 +48,27 @@ PSY.get_component(
 ) where {T <: IS.InfrastructureSystemsComponent} =
     IS.get_component(T, res, name)
 
-PSY.get_component(selector::IS.SingularComponentSelector, res::IS.Results; kwargs...) =
-    IS.get_component(selector, res; kwargs...)
+PSY.get_component(
+    scope_limiter::Union{Function, Nothing},
+    selector::IS.SingularComponentSelector,
+    res::IS.Results,
+) =
+    IS.get_component(scope_limiter, selector, res)
+
+PSY.get_component(selector::IS.SingularComponentSelector, res::IS.Results) =
+    IS.get_component(selector, res)
 
 # get_groups
 """
 Calling `get_groups` on a `Results` is the same as calling [`get_available_groups`](@ref) on
 the system attached to the results.
 """
-PSY.get_groups(selector::IS.ComponentSelector, res::IS.Results; kwargs...) =
-    IS.get_groups(selector, res; kwargs...)
+PSY.get_groups(
+    scope_limiter::Union{Function, Nothing},
+    selector::IS.ComponentSelector,
+    res::IS.Results,
+) =
+    IS.get_groups(scope_limiter, selector, res)
+
+PSY.get_groups(selector::IS.ComponentSelector, res::IS.Results) =
+    IS.get_groups(selector, res)

--- a/src/simulation/simulation_problem_results.jl
+++ b/src/simulation/simulation_problem_results.jl
@@ -742,3 +742,8 @@ function get_component(
     system = _validate_source_data_type(get_system(res))
     return get_available_component(T, system, name)
 end
+
+function get_groups(selector::PSY.ComponentSelector, res::ProblemResultsTypes)
+    system = _validate_source_data_type(get_system(res))
+    return get_available_groups(selector, system)
+end

--- a/src/simulation/simulation_problem_results.jl
+++ b/src/simulation/simulation_problem_results.jl
@@ -60,6 +60,8 @@ function SimulationProblemResults{T}(
     )
 end
 
+const ProblemResultsTypes = Union{OptimizationProblemResults, SimulationProblemResults}
+
 get_model_name(res::SimulationProblemResults) = res.problem
 get_system(res::SimulationProblemResults) = res.system
 get_resolution(res::SimulationProblemResults) = res.resolution
@@ -153,7 +155,7 @@ will include all data. If that was not configured then the returned system will 
 all data except time series data.
 """
 function get_system!(
-    results::Union{OptimizationProblemResults, SimulationProblemResults};
+    results::ProblemResultsTypes;
     kwargs...,
 )
     !isnothing(get_system(results)) && return get_system(results)
@@ -696,3 +698,47 @@ end
 try_resolve_store(user::SimulationStore, results::Union{Nothing, SimulationStore}) = user
 try_resolve_store(user::Nothing, results::SimulationStore) = results
 try_resolve_store(user::Nothing, results::Nothing) = nothing
+
+_validate_source_data_type(::Nothing) =
+    throw(ArgumentError("No system attached, need to call set_system!"))
+
+# In the case of OptimizationProblemResults, our "system" might be an IS type rather than a
+# PSY.System. If `IS.get_components` were the same as `PSY.get_components` etc., this
+# wouldn't be a problem, but in the status quo it is
+# (see https://github.com/NREL-Sienna/InfrastructureSystems.jl/issues/388#issuecomment-2438344086)
+_validate_source_data_type(::IS.InfrastructureSystemsType) =
+    throw(
+        IS.NotImplementedError(
+            "Currently can only call get_components on a set of results whose source data/system is a PowerSystems.jl System",
+        ),
+    )
+
+_validate_source_data_type(data::PSY.System) = data  # Pass through on success
+
+function get_components(::Type{T}, res::ProblemResultsTypes) where {T <: PSY.Component}
+    system = _validate_source_data_type(get_system(res))
+    return get_available_components(T, system)
+end
+
+function get_components(
+    filter_func::Function,
+    ::Type{T},
+    res::ProblemResultsTypes,
+) where {T <: PSY.Component}
+    system = _validate_source_data_type(get_system(res))
+    return get_available_components(filter_func, T, system)
+end
+
+function get_components(selector::PSY.ComponentSelector, res::ProblemResultsTypes)
+    system = _validate_source_data_type(get_system(res))
+    return get_available_components(selector, system)
+end
+
+function get_component(
+    ::Type{T},
+    res::ProblemResultsTypes,
+    name::AbstractString,
+) where {T <: PSY.Component}
+    system = _validate_source_data_type(get_system(res))
+    return get_available_component(T, system, name)
+end

--- a/src/utils/printing.jl
+++ b/src/utils/printing.jl
@@ -487,6 +487,7 @@ function _show_method(io::IO, results::SimulationResults, backend::Symbol; kwarg
     )
 end
 
+ProblemResultsTypes = Union{OptimizationProblemResults, SimulationProblemResults}
 function Base.show(io::IO, ::MIME"text/plain", input::ProblemResultsTypes)
     _show_method(io, input, :auto)
 end

--- a/src/utils/printing.jl
+++ b/src/utils/printing.jl
@@ -487,7 +487,6 @@ function _show_method(io::IO, results::SimulationResults, backend::Symbol; kwarg
     )
 end
 
-ProblemResultsTypes = Union{OptimizationProblemResults, SimulationProblemResults}
 function Base.show(io::IO, ::MIME"text/plain", input::ProblemResultsTypes)
     _show_method(io, input, :auto)
 end

--- a/test/test_model_decision.jl
+++ b/test/test_model_decision.jl
@@ -236,8 +236,13 @@ end
     @test isa(get_realized_timestamps(res), StepRange{DateTime})
     @test isa(IS.Optimization.get_source_data(res), PSY.System)
     @test length(get_timestamps(res)) == 24
+
+    PSY.set_available!(first(get_components(ThermalStandard, get_system(res))), false)
     @test collect(get_components(ThermalStandard, res)) ==
           collect(get_available_components(ThermalStandard, get_system(res)))
+    sel = PSY.make_selector(ThermalStandard; groupby = :each)
+    @test collect(get_groups(sel, res)) ==
+          collect(get_available_groups(sel, get_system(res)))
 end
 
 @testset "Solve DecisionModelModel with auto-build" begin

--- a/test/test_model_decision.jl
+++ b/test/test_model_decision.jl
@@ -236,6 +236,8 @@ end
     @test isa(get_realized_timestamps(res), StepRange{DateTime})
     @test isa(IS.Optimization.get_source_data(res), PSY.System)
     @test length(get_timestamps(res)) == 24
+    @test collect(get_components(ThermalStandard, res)) ==
+          collect(get_available_components(ThermalStandard, get_system(res)))
 end
 
 @testset "Solve DecisionModelModel with auto-build" begin

--- a/test/test_simulation_results.jl
+++ b/test/test_simulation_results.jl
@@ -313,6 +313,11 @@ function test_decision_problem_results_values(
     @test IS.get_uuid(get_system(results_uc)) === IS.get_uuid(c_sys5_hy_uc)
     @test IS.get_uuid(get_system(results_ed)) === IS.get_uuid(c_sys5_hy_ed)
 
+    @test collect(get_components(ThermalStandard, results_uc)) ==
+          collect(get_available_components(ThermalStandard, get_system(results_uc)))
+    @test collect(get_components(ThermalStandard, results_ed)) ==
+          collect(get_available_components(ThermalStandard, get_system(results_ed)))
+
     @test isempty(setdiff(UC_EXPECTED_VARS, list_variable_names(results_uc)))
     @test isempty(setdiff(ED_EXPECTED_VARS, list_variable_names(results_ed)))
 

--- a/test/test_simulation_results.jl
+++ b/test/test_simulation_results.jl
@@ -313,10 +313,22 @@ function test_decision_problem_results_values(
     @test IS.get_uuid(get_system(results_uc)) === IS.get_uuid(c_sys5_hy_uc)
     @test IS.get_uuid(get_system(results_ed)) === IS.get_uuid(c_sys5_hy_ed)
 
+    # Temporarily mark some stuff unavailable
+    unav_uc = first(PSY.get_available_components(ThermalStandard, get_system(results_uc)))
+    PSY.set_available!(unav_uc, false)
+    unav_ed = first(PSY.get_available_components(ThermalStandard, get_system(results_ed)))
+    PSY.set_available!(unav_ed, false)
+    sel = PSY.make_selector(ThermalStandard; groupby = :each)
     @test collect(get_components(ThermalStandard, results_uc)) ==
           collect(get_available_components(ThermalStandard, get_system(results_uc)))
     @test collect(get_components(ThermalStandard, results_ed)) ==
           collect(get_available_components(ThermalStandard, get_system(results_ed)))
+    @test collect(get_groups(sel, results_uc)) ==
+          collect(get_available_groups(sel, get_system(results_uc)))
+    @test collect(get_groups(sel, results_ed)) ==
+          collect(get_available_groups(sel, get_system(results_ed)))
+    PSY.set_available!(unav_uc, true)
+    PSY.set_available!(unav_ed, true)
 
     @test isempty(setdiff(UC_EXPECTED_VARS, list_variable_names(results_uc)))
     @test isempty(setdiff(ED_EXPECTED_VARS, list_variable_names(results_ed)))


### PR DESCRIPTION
Companion to and dependent on

- https://github.com/NREL-Sienna/InfrastructureSystems.jl/pull/342
- https://github.com/NREL-Sienna/PowerSystems.jl/pull/1197

. The main thing here is we want `get_components` to work on `IS.Results` such that `get_components` on a `Results` is like `get_available_components` on its attached `System` (or attached `IS.SystemData`, etc.). The implementation of this behavior is in the IS PR, but following the design set out [here](https://github.com/NREL-Sienna/PowerSystems.jl/blob/037435f4d7c0198c52e0fa29af0d05f7ee364bc7/src/get_components_interface.jl#L1), we need to define `PSY.get_components` aliases that redirect to the appropriate `IS.get_components` methods to keep the documentation user-friendly. That cannot be done in IS and (correct me if I'm wrong) it doesn't really make sense to do in PSY, so it is done here.