### PR TITLE
Add Thermal Slacks for UB and LB constraints (including ramps)

### DIFF
--- a/docs/src/api/PowerSimulations.md
+++ b/docs/src/api/PowerSimulations.md
@@ -150,8 +150,8 @@ For a list of variables for each device refer to its Formulations page.
 ActivePowerVariable
 ReactivePowerVariable
 PieceWiseLinearCostVariable
-ActivePowerVariableSlackUp
-ActivePowerVariableSlackDown
+RateofChangeConstraintSlackUp
+RateofChangeConstraintSlackDown
 ```
 
 ### Thermal Unit Variables

--- a/docs/src/api/PowerSimulations.md
+++ b/docs/src/api/PowerSimulations.md
@@ -150,6 +150,8 @@ For a list of variables for each device refer to its Formulations page.
 ActivePowerVariable
 ReactivePowerVariable
 PieceWiseLinearCostVariable
+ActivePowerVariableSlackUp
+ActivePowerVariableSlackDown
 ```
 
 ### Thermal Unit Variables

--- a/docs/src/formulation_library/ThermalGen.md
+++ b/docs/src/formulation_library/ThermalGen.md
@@ -198,6 +198,22 @@ ThermalStandardDispatch
       + Bounds: [0.0, ]
       + Symbol: ``q^\text{th}``
 
+If Slack variables are enabled (`use_slacks = true`):
+
+  - [`RateofChangeConstraintSlackUp`](@ref):
+    
+      + Bounds: [0.0, ]
+      + Default initial value: 0.0
+      + Default proportional cost: 2e5
+      + Symbol: ``p^\text{sl,up}``
+
+  - [`RateofChangeConstraintSlackDown`](@ref):
+    
+      + Bounds: [0.0, ]
+      + Default initial value: 0.0
+      + Default proportional cost: 2e5
+      + Symbol: ``p^\text{sl,dn}``
+
 **Static Parameters:**
 
   - ``P^\text{th,min}`` = `PowerSystems.get_active_power_limits(device).min`
@@ -223,8 +239,10 @@ For each thermal unit creates the range constraints for its active and reactive 
 \begin{align*}
 &  P^\text{th,min} \le p^\text{th}_t \le P^\text{th,max}, \quad \forall t\in \{1, \dots, T\} \\
 &  Q^\text{th,min} \le q^\text{th}_t \le Q^\text{th,max}, \quad \forall t\in \{1, \dots, T\} \\
-& -R^\text{th,dn} \le  p_1^\text{th} - p^\text{th, init} \le R^\text{th,up} \\
-& -R^\text{th,dn} \le p_t^\text{th} - p_{t-1}^\text{th} \le R^\text{th,up}, \quad \forall  t\in \{2, \dots, T\}
+& p_1^\text{th} - p^\text{th, init} - p_1^\text{sl,up} \le R^\text{th,up} \\
+& p_t^\text{th} - p_{t-1}^\text{th} - p_t^\text{sl,up}\le R^\text{th,up}, \quad \forall  t\in \{2, \dots, T\} \\
+& -R^\text{th,dn} \le  p_1^\text{th} - p^\text{th, init} + p_1^\text{sl,dn} \\
+&  -R^\text{th,dn} \le p_t^\text{th} - p_{t-1}^\text{th} + p_t^\text{sl,dn}, \quad \forall  t\in \{2, \dots, T\} \\
 \end{align*}
 ```
 
@@ -498,6 +516,22 @@ ThermalStandardUnitCommitment
       + Bounds: ``\{0,1\}``
       + Symbol: ``w_t^\text{th}``
 
+If Slack variables are enabled (`use_slacks = true`):
+
+  - [`RateofChangeConstraintSlackUp`](@ref):
+    
+      + Bounds: [0.0, ]
+      + Default initial value: 0.0
+      + Default proportional cost: 2e5
+      + Symbol: ``p^\text{sl,up}``
+
+  - [`RateofChangeConstraintSlackDown`](@ref):
+    
+      + Bounds: [0.0, ]
+      + Default initial value: 0.0
+      + Default proportional cost: 2e5
+      + Symbol: ``p^\text{sl,dn}``
+
 **Auxiliary Variables:**
 
   - [`TimeDurationOn`](@ref):
@@ -537,8 +571,10 @@ For each thermal unit creates the range constraints for its active and reactive 
 \begin{align*}
 &  u^\text{th}_t P^\text{th,min} \le  p^\text{th}_t \le u^\text{th}_t P^\text{th,max}, \quad \forall t\in \{1, \dots, T\} \\
 &  u_t^\text{th} Q^\text{th,min} \le q^\text{th}_t \le u_t^\text{th} Q^\text{th,max}, \quad \forall t\in \{1, \dots, T\} \\
-& -R^\text{th,dn} \le p_1^\text{th} -  p^\text{th, init} \le R^\text{th,up} \\
-& -R^\text{th,dn} \le  p_t^\text{th} -  p_{t-1}^\text{th} \le R^\text{th,up}, \quad \forall  t\in \{2, \dots, T\} \\
+& p_1^\text{th} -  p^\text{th, init} - p_1^\text{sl,up} \le R^\text{th,up} \\
+& p_t^\text{th} -  p_{t-1}^\text{th} - p_t^\text{sl,up} \le R^\text{th,up}, \quad \forall  t\in \{2, \dots, T\} \\
+& -R^\text{th,dn} \le p_1^\text{th} -  p^\text{th, init} + p_1^\text{sl,dn} \\
+& -R^\text{th,dn} \le  p_t^\text{th} -  p_{t-1}^\text{th} + p_t^\text{sl,dn}, \quad \forall  t\in \{2, \dots, T\} \\
 & u_1^\text{th} = u^\text{th,init} + v_1^\text{th} - w_1^\text{th} \\
 & u_t^\text{th} = u_{t-1}^\text{th} + v_t^\text{th} - w_t^\text{th}, \quad \forall t \in \{2,\dots,T\} \\
 & v_t^\text{th} + w_t^\text{th} \le 1, \quad \forall t \in \{1,\dots,T\} 

--- a/src/PowerSimulations.jl
+++ b/src/PowerSimulations.jl
@@ -233,6 +233,8 @@ export LowerBoundFeedForwardSlack
 export InterfaceFlowSlackUp
 export InterfaceFlowSlackDown
 export PieceWiseLinearCostVariable
+export ActivePowerVariableSlackUB
+export ActivePowerVariableSlackLB
 
 # Auxiliary variables
 export TimeDurationOn

--- a/src/PowerSimulations.jl
+++ b/src/PowerSimulations.jl
@@ -233,8 +233,8 @@ export LowerBoundFeedForwardSlack
 export InterfaceFlowSlackUp
 export InterfaceFlowSlackDown
 export PieceWiseLinearCostVariable
-export ActivePowerVariableSlackUB
-export ActivePowerVariableSlackLB
+export ActivePowerVariableSlackUp
+export ActivePowerVariableSlackDown
 
 # Auxiliary variables
 export TimeDurationOn

--- a/src/PowerSimulations.jl
+++ b/src/PowerSimulations.jl
@@ -233,8 +233,8 @@ export LowerBoundFeedForwardSlack
 export InterfaceFlowSlackUp
 export InterfaceFlowSlackDown
 export PieceWiseLinearCostVariable
-export ActivePowerVariableSlackUp
-export ActivePowerVariableSlackDown
+export RateofChangeConstraintSlackUp
+export RateofChangeConstraintSlackDown
 
 # Auxiliary variables
 export TimeDurationOn

--- a/src/core/variables.jl
+++ b/src/core/variables.jl
@@ -303,13 +303,13 @@ Struct to dispatch the creation of Slack variables for UB limits
 
 Docs abbreviation: ``p^\\text{x,ubsl}``
 """
-struct ActivePowerVariableSlackUp <: VariableType end
+struct RateofChangeConstraintSlackUp <: VariableType end
 """
 Struct to dispatch the creation of Slack variables for LB limits
 
 Docs abbreviation: ``p^\\text{x,lbsl}``
 """
-struct ActivePowerVariableSlackDown <: VariableType end
+struct RateofChangeConstraintSlackDown <: VariableType end
 
 const START_VARIABLES = (HotStartVariable, WarmStartVariable, ColdStartVariable)
 
@@ -325,8 +325,8 @@ convert_result_to_natural_units(::Type{EnergyVariable}) = true
 convert_result_to_natural_units(::Type{ReactivePowerVariable}) = true
 convert_result_to_natural_units(::Type{ActivePowerReserveVariable}) = true
 convert_result_to_natural_units(::Type{ServiceRequirementVariable}) = true
-convert_result_to_natural_units(::Type{ActivePowerVariableSlackUp}) = true
-convert_result_to_natural_units(::Type{ActivePowerVariableSlackDown}) = true
+convert_result_to_natural_units(::Type{RateofChangeConstraintSlackUp}) = true
+convert_result_to_natural_units(::Type{RateofChangeConstraintSlackDown}) = true
 convert_result_to_natural_units(::Type{AreaMismatchVariable}) = true
 convert_result_to_natural_units(::Type{DeltaActivePowerUpVariable}) = true
 convert_result_to_natural_units(::Type{DeltaActivePowerDownVariable}) = true

--- a/src/core/variables.jl
+++ b/src/core/variables.jl
@@ -303,13 +303,13 @@ Struct to dispatch the creation of Slack variables for UB limits
 
 Docs abbreviation: ``p^\\text{x,ubsl}``
 """
-struct ActivePowerVariableSlackUB <: VariableType end
+struct ActivePowerVariableSlackUp <: VariableType end
 """
 Struct to dispatch the creation of Slack variables for LB limits
 
 Docs abbreviation: ``p^\\text{x,lbsl}``
 """
-struct ActivePowerVariableSlackLB <: VariableType end
+struct ActivePowerVariableSlackDown <: VariableType end
 
 const START_VARIABLES = (HotStartVariable, WarmStartVariable, ColdStartVariable)
 
@@ -325,8 +325,8 @@ convert_result_to_natural_units(::Type{EnergyVariable}) = true
 convert_result_to_natural_units(::Type{ReactivePowerVariable}) = true
 convert_result_to_natural_units(::Type{ActivePowerReserveVariable}) = true
 convert_result_to_natural_units(::Type{ServiceRequirementVariable}) = true
-convert_result_to_natural_units(::Type{ActivePowerVariableSlackUB}) = true
-convert_result_to_natural_units(::Type{ActivePowerVariableSlackLB}) = true
+convert_result_to_natural_units(::Type{ActivePowerVariableSlackUp}) = true
+convert_result_to_natural_units(::Type{ActivePowerVariableSlackDown}) = true
 convert_result_to_natural_units(::Type{AreaMismatchVariable}) = true
 convert_result_to_natural_units(::Type{DeltaActivePowerUpVariable}) = true
 convert_result_to_natural_units(::Type{DeltaActivePowerDownVariable}) = true

--- a/src/core/variables.jl
+++ b/src/core/variables.jl
@@ -299,15 +299,15 @@ Docs abbreviation: ``p^\\text{ff,lbsl}``
 struct LowerBoundFeedForwardSlack <: VariableType end
 
 """
-Struct to dispatch the creation of Slack variables for UB limits
+Struct to dispatch the creation of Slack variables for rate of change constraints up limits
 
-Docs abbreviation: ``p^\\text{x,ubsl}``
+Docs abbreviation: ``p^\\text{sl,up}``
 """
 struct RateofChangeConstraintSlackUp <: VariableType end
 """
-Struct to dispatch the creation of Slack variables for LB limits
+Struct to dispatch the creation of Slack variables for rate of change constraints down limits
 
-Docs abbreviation: ``p^\\text{x,lbsl}``
+Docs abbreviation: ``p^\\text{sl,dn}``
 """
 struct RateofChangeConstraintSlackDown <: VariableType end
 

--- a/src/core/variables.jl
+++ b/src/core/variables.jl
@@ -298,6 +298,19 @@ Docs abbreviation: ``p^\\text{ff,lbsl}``
 """
 struct LowerBoundFeedForwardSlack <: VariableType end
 
+"""
+Struct to dispatch the creation of Slack variables for UB limits
+
+Docs abbreviation: ``p^\\text{x,ubsl}``
+"""
+struct ActivePowerVariableSlackUB <: VariableType end
+"""
+Struct to dispatch the creation of Slack variables for LB limits
+
+Docs abbreviation: ``p^\\text{x,lbsl}``
+"""
+struct ActivePowerVariableSlackLB <: VariableType end
+
 const START_VARIABLES = (HotStartVariable, WarmStartVariable, ColdStartVariable)
 
 should_write_resulting_value(::Type{PieceWiseLinearCostVariable}) = false
@@ -312,6 +325,8 @@ convert_result_to_natural_units(::Type{EnergyVariable}) = true
 convert_result_to_natural_units(::Type{ReactivePowerVariable}) = true
 convert_result_to_natural_units(::Type{ActivePowerReserveVariable}) = true
 convert_result_to_natural_units(::Type{ServiceRequirementVariable}) = true
+convert_result_to_natural_units(::Type{ActivePowerVariableSlackUB}) = true
+convert_result_to_natural_units(::Type{ActivePowerVariableSlackLB}) = true
 convert_result_to_natural_units(::Type{AreaMismatchVariable}) = true
 convert_result_to_natural_units(::Type{DeltaActivePowerUpVariable}) = true
 convert_result_to_natural_units(::Type{DeltaActivePowerDownVariable}) = true

--- a/src/devices_models/device_constructors/thermalgeneration_constructor.jl
+++ b/src/devices_models/device_constructors/thermalgeneration_constructor.jl
@@ -107,6 +107,26 @@ function construct_device!(
         devices,
         model,
     )
+    if get_use_slacks(model)
+        add_variables!(container, ActivePowerVariableSlackUB, devices, D())
+        add_variables!(container, ActivePowerVariableSlackLB, devices, D())
+        add_to_expression!(
+            container,
+            ActivePowerRangeExpressionLB,
+            ActivePowerVariableSlackLB,
+            devices,
+            model,
+            network_model,
+        )
+        add_to_expression!(
+            container,
+            ActivePowerRangeExpressionUB,
+            ActivePowerVariableSlackUB,
+            devices,
+            model,
+            network_model,
+        )
+    end
     add_feedforward_arguments!(container, model, devices)
     return
 end
@@ -233,6 +253,26 @@ function construct_device!(
         devices,
         model,
     )
+    if get_use_slacks(model)
+        add_variables!(container, ActivePowerVariableSlackUB, devices, D())
+        add_variables!(container, ActivePowerVariableSlackLB, devices, D())
+        add_to_expression!(
+            container,
+            ActivePowerRangeExpressionLB,
+            ActivePowerVariableSlackLB,
+            devices,
+            model,
+            network_model,
+        )
+        add_to_expression!(
+            container,
+            ActivePowerRangeExpressionUB,
+            ActivePowerVariableSlackUB,
+            devices,
+            model,
+            network_model,
+        )
+    end
 
     add_feedforward_arguments!(container, model, devices)
     return
@@ -358,6 +398,36 @@ function construct_device!(
         devices,
         model,
     )
+    if get_use_slacks(model)
+        add_variables!(
+            container,
+            ActivePowerVariableSlackUB,
+            devices,
+            ThermalBasicUnitCommitment(),
+        )
+        add_variables!(
+            container,
+            ActivePowerVariableSlackLB,
+            devices,
+            ThermalBasicUnitCommitment(),
+        )
+        add_to_expression!(
+            container,
+            ActivePowerRangeExpressionLB,
+            ActivePowerVariableSlackLB,
+            devices,
+            model,
+            network_model,
+        )
+        add_to_expression!(
+            container,
+            ActivePowerRangeExpressionUB,
+            ActivePowerVariableSlackUB,
+            devices,
+            model,
+            network_model,
+        )
+    end
 
     add_feedforward_arguments!(container, model, devices)
     return
@@ -481,6 +551,36 @@ function construct_device!(
         devices,
         model,
     )
+    if get_use_slacks(model)
+        add_variables!(
+            container,
+            ActivePowerVariableSlackUB,
+            devices,
+            ThermalBasicUnitCommitment(),
+        )
+        add_variables!(
+            container,
+            ActivePowerVariableSlackLB,
+            devices,
+            ThermalBasicUnitCommitment(),
+        )
+        add_to_expression!(
+            container,
+            ActivePowerRangeExpressionLB,
+            ActivePowerVariableSlackLB,
+            devices,
+            model,
+            network_model,
+        )
+        add_to_expression!(
+            container,
+            ActivePowerRangeExpressionUB,
+            ActivePowerVariableSlackUB,
+            devices,
+            model,
+            network_model,
+        )
+    end
 
     add_feedforward_arguments!(container, model, devices)
     return
@@ -598,6 +698,36 @@ function construct_device!(
         devices,
         model,
     )
+    if get_use_slacks(model)
+        add_variables!(
+            container,
+            ActivePowerVariableSlackUB,
+            devices,
+            ThermalStandardDispatch(),
+        )
+        add_variables!(
+            container,
+            ActivePowerVariableSlackLB,
+            devices,
+            ThermalStandardDispatch(),
+        )
+        add_to_expression!(
+            container,
+            ActivePowerRangeExpressionLB,
+            ActivePowerVariableSlackLB,
+            devices,
+            model,
+            network_model,
+        )
+        add_to_expression!(
+            container,
+            ActivePowerRangeExpressionUB,
+            ActivePowerVariableSlackUB,
+            devices,
+            model,
+            network_model,
+        )
+    end
 
     add_feedforward_arguments!(container, model, devices)
     return
@@ -704,6 +834,36 @@ function construct_device!(
         devices,
         model,
     )
+    if get_use_slacks(model)
+        add_variables!(
+            container,
+            ActivePowerVariableSlackUB,
+            devices,
+            ThermalStandardDispatch(),
+        )
+        add_variables!(
+            container,
+            ActivePowerVariableSlackLB,
+            devices,
+            ThermalStandardDispatch(),
+        )
+        add_to_expression!(
+            container,
+            ActivePowerRangeExpressionLB,
+            ActivePowerVariableSlackLB,
+            devices,
+            model,
+            network_model,
+        )
+        add_to_expression!(
+            container,
+            ActivePowerRangeExpressionUB,
+            ActivePowerVariableSlackUB,
+            devices,
+            model,
+            network_model,
+        )
+    end
 
     add_feedforward_arguments!(container, model, devices)
     return
@@ -809,6 +969,26 @@ function construct_device!(
         devices,
         model,
     )
+    if get_use_slacks(model)
+        add_variables!(container, ActivePowerVariableSlackUB, devices, D())
+        add_variables!(container, ActivePowerVariableSlackLB, devices, D())
+        add_to_expression!(
+            container,
+            ActivePowerRangeExpressionLB,
+            ActivePowerVariableSlackLB,
+            devices,
+            model,
+            network_model,
+        )
+        add_to_expression!(
+            container,
+            ActivePowerRangeExpressionUB,
+            ActivePowerVariableSlackUB,
+            devices,
+            model,
+            network_model,
+        )
+    end
 
     add_feedforward_arguments!(container, model, devices)
     return
@@ -909,6 +1089,26 @@ function construct_device!(
         devices,
         model,
     )
+    if get_use_slacks(model)
+        add_variables!(container, ActivePowerVariableSlackUB, devices, D())
+        add_variables!(container, ActivePowerVariableSlackLB, devices, D())
+        add_to_expression!(
+            container,
+            ActivePowerRangeExpressionLB,
+            ActivePowerVariableSlackLB,
+            devices,
+            model,
+            network_model,
+        )
+        add_to_expression!(
+            container,
+            ActivePowerRangeExpressionUB,
+            ActivePowerVariableSlackUB,
+            devices,
+            model,
+            network_model,
+        )
+    end
 
     add_feedforward_arguments!(container, model, devices)
     return
@@ -1039,6 +1239,36 @@ function construct_device!(
         devices,
         model,
     )
+    if get_use_slacks(model)
+        add_variables!(
+            container,
+            ActivePowerVariableSlackUB,
+            devices,
+            ThermalMultiStartUnitCommitment(),
+        )
+        add_variables!(
+            container,
+            ActivePowerVariableSlackLB,
+            devices,
+            ThermalMultiStartUnitCommitment(),
+        )
+        add_to_expression!(
+            container,
+            ActivePowerRangeExpressionLB,
+            ActivePowerVariableSlackLB,
+            devices,
+            model,
+            network_model,
+        )
+        add_to_expression!(
+            container,
+            ActivePowerRangeExpressionUB,
+            ActivePowerVariableSlackUB,
+            devices,
+            model,
+            network_model,
+        )
+    end
 
     add_feedforward_arguments!(container, model, devices)
     return
@@ -1192,6 +1422,36 @@ function construct_device!(
         devices,
         model,
     )
+    if get_use_slacks(model)
+        add_variables!(
+            container,
+            ActivePowerVariableSlackUB,
+            devices,
+            ThermalMultiStartUnitCommitment(),
+        )
+        add_variables!(
+            container,
+            ActivePowerVariableSlackLB,
+            devices,
+            ThermalMultiStartUnitCommitment(),
+        )
+        add_to_expression!(
+            container,
+            ActivePowerRangeExpressionLB,
+            ActivePowerVariableSlackLB,
+            devices,
+            model,
+            network_model,
+        )
+        add_to_expression!(
+            container,
+            ActivePowerRangeExpressionUB,
+            ActivePowerVariableSlackUB,
+            devices,
+            model,
+            network_model,
+        )
+    end
 
     add_feedforward_arguments!(container, model, devices)
     return
@@ -1343,6 +1603,36 @@ function construct_device!(
         devices,
         model,
     )
+    if get_use_slacks(model)
+        add_variables!(
+            container,
+            ActivePowerVariableSlackUB,
+            devices,
+            ThermalCompactUnitCommitment(),
+        )
+        add_variables!(
+            container,
+            ActivePowerVariableSlackLB,
+            devices,
+            ThermalCompactUnitCommitment(),
+        )
+        add_to_expression!(
+            container,
+            ActivePowerRangeExpressionLB,
+            ActivePowerVariableSlackLB,
+            devices,
+            model,
+            network_model,
+        )
+        add_to_expression!(
+            container,
+            ActivePowerRangeExpressionUB,
+            ActivePowerVariableSlackUB,
+            devices,
+            model,
+            network_model,
+        )
+    end
 
     add_feedforward_arguments!(container, model, devices)
     return
@@ -1478,6 +1768,36 @@ function construct_device!(
         devices,
         model,
     )
+    if get_use_slacks(model)
+        add_variables!(
+            container,
+            ActivePowerVariableSlackUB,
+            devices,
+            ThermalCompactUnitCommitment(),
+        )
+        add_variables!(
+            container,
+            ActivePowerVariableSlackLB,
+            devices,
+            ThermalCompactUnitCommitment(),
+        )
+        add_to_expression!(
+            container,
+            ActivePowerRangeExpressionLB,
+            ActivePowerVariableSlackLB,
+            devices,
+            model,
+            network_model,
+        )
+        add_to_expression!(
+            container,
+            ActivePowerRangeExpressionUB,
+            ActivePowerVariableSlackUB,
+            devices,
+            model,
+            network_model,
+        )
+    end
     add_feedforward_arguments!(container, model, devices)
     return
 end
@@ -1608,6 +1928,36 @@ function construct_device!(
         devices,
         model,
     )
+    if get_use_slacks(model)
+        add_variables!(
+            container,
+            ActivePowerVariableSlackUB,
+            devices,
+            ThermalBasicCompactUnitCommitment(),
+        )
+        add_variables!(
+            container,
+            ActivePowerVariableSlackLB,
+            devices,
+            ThermalBasicCompactUnitCommitment(),
+        )
+        add_to_expression!(
+            container,
+            ActivePowerRangeExpressionLB,
+            ActivePowerVariableSlackLB,
+            devices,
+            model,
+            network_model,
+        )
+        add_to_expression!(
+            container,
+            ActivePowerRangeExpressionUB,
+            ActivePowerVariableSlackUB,
+            devices,
+            model,
+            network_model,
+        )
+    end
 
     add_feedforward_arguments!(container, model, devices)
     return
@@ -1739,6 +2089,36 @@ function construct_device!(
         devices,
         model,
     )
+    if get_use_slacks(model)
+        add_variables!(
+            container,
+            ActivePowerVariableSlackUB,
+            devices,
+            ThermalBasicCompactUnitCommitment(),
+        )
+        add_variables!(
+            container,
+            ActivePowerVariableSlackLB,
+            devices,
+            ThermalBasicCompactUnitCommitment(),
+        )
+        add_to_expression!(
+            container,
+            ActivePowerRangeExpressionLB,
+            ActivePowerVariableSlackLB,
+            devices,
+            model,
+            network_model,
+        )
+        add_to_expression!(
+            container,
+            ActivePowerRangeExpressionUB,
+            ActivePowerVariableSlackUB,
+            devices,
+            model,
+            network_model,
+        )
+    end
     add_feedforward_arguments!(container, model, devices)
     return
 end
@@ -1863,6 +2243,36 @@ function construct_device!(
         devices,
         model,
     )
+    if get_use_slacks(model)
+        add_variables!(
+            container,
+            ActivePowerVariableSlackUB,
+            devices,
+            ThermalCompactDispatch(),
+        )
+        add_variables!(
+            container,
+            ActivePowerVariableSlackLB,
+            devices,
+            ThermalCompactDispatch(),
+        )
+        add_to_expression!(
+            container,
+            ActivePowerRangeExpressionLB,
+            ActivePowerVariableSlackLB,
+            devices,
+            model,
+            network_model,
+        )
+        add_to_expression!(
+            container,
+            ActivePowerRangeExpressionUB,
+            ActivePowerVariableSlackUB,
+            devices,
+            model,
+            network_model,
+        )
+    end
     return
 end
 
@@ -1976,6 +2386,36 @@ function construct_device!(
         devices,
         model,
     )
+    if get_use_slacks(model)
+        add_variables!(
+            container,
+            ActivePowerVariableSlackUB,
+            devices,
+            ThermalCompactDispatch(),
+        )
+        add_variables!(
+            container,
+            ActivePowerVariableSlackLB,
+            devices,
+            ThermalCompactDispatch(),
+        )
+        add_to_expression!(
+            container,
+            ActivePowerRangeExpressionLB,
+            ActivePowerVariableSlackLB,
+            devices,
+            model,
+            network_model,
+        )
+        add_to_expression!(
+            container,
+            ActivePowerRangeExpressionUB,
+            ActivePowerVariableSlackUB,
+            devices,
+            model,
+            network_model,
+        )
+    end
     return
 end
 

--- a/src/devices_models/device_constructors/thermalgeneration_constructor.jl
+++ b/src/devices_models/device_constructors/thermalgeneration_constructor.jl
@@ -108,24 +108,8 @@ function construct_device!(
         model,
     )
     if get_use_slacks(model)
-        add_variables!(container, ActivePowerVariableSlackUB, devices, D())
-        add_variables!(container, ActivePowerVariableSlackLB, devices, D())
-        add_to_expression!(
-            container,
-            ActivePowerRangeExpressionLB,
-            ActivePowerVariableSlackLB,
-            devices,
-            model,
-            network_model,
-        )
-        add_to_expression!(
-            container,
-            ActivePowerRangeExpressionUB,
-            ActivePowerVariableSlackUB,
-            devices,
-            model,
-            network_model,
-        )
+        add_variables!(container, ActivePowerVariableSlackUp, devices, D())
+        add_variables!(container, ActivePowerVariableSlackDown, devices, D())
     end
     add_feedforward_arguments!(container, model, devices)
     return
@@ -254,24 +238,8 @@ function construct_device!(
         model,
     )
     if get_use_slacks(model)
-        add_variables!(container, ActivePowerVariableSlackUB, devices, D())
-        add_variables!(container, ActivePowerVariableSlackLB, devices, D())
-        add_to_expression!(
-            container,
-            ActivePowerRangeExpressionLB,
-            ActivePowerVariableSlackLB,
-            devices,
-            model,
-            network_model,
-        )
-        add_to_expression!(
-            container,
-            ActivePowerRangeExpressionUB,
-            ActivePowerVariableSlackUB,
-            devices,
-            model,
-            network_model,
-        )
+        add_variables!(container, ActivePowerVariableSlackUp, devices, D())
+        add_variables!(container, ActivePowerVariableSlackDown, devices, D())
     end
 
     add_feedforward_arguments!(container, model, devices)
@@ -401,31 +369,15 @@ function construct_device!(
     if get_use_slacks(model)
         add_variables!(
             container,
-            ActivePowerVariableSlackUB,
+            ActivePowerVariableSlackUp,
             devices,
             ThermalBasicUnitCommitment(),
         )
         add_variables!(
             container,
-            ActivePowerVariableSlackLB,
+            ActivePowerVariableSlackDown,
             devices,
             ThermalBasicUnitCommitment(),
-        )
-        add_to_expression!(
-            container,
-            ActivePowerRangeExpressionLB,
-            ActivePowerVariableSlackLB,
-            devices,
-            model,
-            network_model,
-        )
-        add_to_expression!(
-            container,
-            ActivePowerRangeExpressionUB,
-            ActivePowerVariableSlackUB,
-            devices,
-            model,
-            network_model,
         )
     end
 
@@ -554,31 +506,15 @@ function construct_device!(
     if get_use_slacks(model)
         add_variables!(
             container,
-            ActivePowerVariableSlackUB,
+            ActivePowerVariableSlackUp,
             devices,
             ThermalBasicUnitCommitment(),
         )
         add_variables!(
             container,
-            ActivePowerVariableSlackLB,
+            ActivePowerVariableSlackDown,
             devices,
             ThermalBasicUnitCommitment(),
-        )
-        add_to_expression!(
-            container,
-            ActivePowerRangeExpressionLB,
-            ActivePowerVariableSlackLB,
-            devices,
-            model,
-            network_model,
-        )
-        add_to_expression!(
-            container,
-            ActivePowerRangeExpressionUB,
-            ActivePowerVariableSlackUB,
-            devices,
-            model,
-            network_model,
         )
     end
 
@@ -701,31 +637,15 @@ function construct_device!(
     if get_use_slacks(model)
         add_variables!(
             container,
-            ActivePowerVariableSlackUB,
+            ActivePowerVariableSlackUp,
             devices,
             ThermalStandardDispatch(),
         )
         add_variables!(
             container,
-            ActivePowerVariableSlackLB,
+            ActivePowerVariableSlackDown,
             devices,
             ThermalStandardDispatch(),
-        )
-        add_to_expression!(
-            container,
-            ActivePowerRangeExpressionLB,
-            ActivePowerVariableSlackLB,
-            devices,
-            model,
-            network_model,
-        )
-        add_to_expression!(
-            container,
-            ActivePowerRangeExpressionUB,
-            ActivePowerVariableSlackUB,
-            devices,
-            model,
-            network_model,
         )
     end
 
@@ -837,31 +757,15 @@ function construct_device!(
     if get_use_slacks(model)
         add_variables!(
             container,
-            ActivePowerVariableSlackUB,
+            ActivePowerVariableSlackUp,
             devices,
             ThermalStandardDispatch(),
         )
         add_variables!(
             container,
-            ActivePowerVariableSlackLB,
+            ActivePowerVariableSlackDown,
             devices,
             ThermalStandardDispatch(),
-        )
-        add_to_expression!(
-            container,
-            ActivePowerRangeExpressionLB,
-            ActivePowerVariableSlackLB,
-            devices,
-            model,
-            network_model,
-        )
-        add_to_expression!(
-            container,
-            ActivePowerRangeExpressionUB,
-            ActivePowerVariableSlackUB,
-            devices,
-            model,
-            network_model,
         )
     end
 
@@ -970,24 +874,8 @@ function construct_device!(
         model,
     )
     if get_use_slacks(model)
-        add_variables!(container, ActivePowerVariableSlackUB, devices, D())
-        add_variables!(container, ActivePowerVariableSlackLB, devices, D())
-        add_to_expression!(
-            container,
-            ActivePowerRangeExpressionLB,
-            ActivePowerVariableSlackLB,
-            devices,
-            model,
-            network_model,
-        )
-        add_to_expression!(
-            container,
-            ActivePowerRangeExpressionUB,
-            ActivePowerVariableSlackUB,
-            devices,
-            model,
-            network_model,
-        )
+        add_variables!(container, ActivePowerVariableSlackUp, devices, D())
+        add_variables!(container, ActivePowerVariableSlackDown, devices, D())
     end
 
     add_feedforward_arguments!(container, model, devices)
@@ -1090,24 +978,8 @@ function construct_device!(
         model,
     )
     if get_use_slacks(model)
-        add_variables!(container, ActivePowerVariableSlackUB, devices, D())
-        add_variables!(container, ActivePowerVariableSlackLB, devices, D())
-        add_to_expression!(
-            container,
-            ActivePowerRangeExpressionLB,
-            ActivePowerVariableSlackLB,
-            devices,
-            model,
-            network_model,
-        )
-        add_to_expression!(
-            container,
-            ActivePowerRangeExpressionUB,
-            ActivePowerVariableSlackUB,
-            devices,
-            model,
-            network_model,
-        )
+        add_variables!(container, ActivePowerVariableSlackUp, devices, D())
+        add_variables!(container, ActivePowerVariableSlackDown, devices, D())
     end
 
     add_feedforward_arguments!(container, model, devices)
@@ -1242,31 +1114,15 @@ function construct_device!(
     if get_use_slacks(model)
         add_variables!(
             container,
-            ActivePowerVariableSlackUB,
+            ActivePowerVariableSlackUp,
             devices,
             ThermalMultiStartUnitCommitment(),
         )
         add_variables!(
             container,
-            ActivePowerVariableSlackLB,
+            ActivePowerVariableSlackDown,
             devices,
             ThermalMultiStartUnitCommitment(),
-        )
-        add_to_expression!(
-            container,
-            ActivePowerRangeExpressionLB,
-            ActivePowerVariableSlackLB,
-            devices,
-            model,
-            network_model,
-        )
-        add_to_expression!(
-            container,
-            ActivePowerRangeExpressionUB,
-            ActivePowerVariableSlackUB,
-            devices,
-            model,
-            network_model,
         )
     end
 
@@ -1425,31 +1281,15 @@ function construct_device!(
     if get_use_slacks(model)
         add_variables!(
             container,
-            ActivePowerVariableSlackUB,
+            ActivePowerVariableSlackUp,
             devices,
             ThermalMultiStartUnitCommitment(),
         )
         add_variables!(
             container,
-            ActivePowerVariableSlackLB,
+            ActivePowerVariableSlackDown,
             devices,
             ThermalMultiStartUnitCommitment(),
-        )
-        add_to_expression!(
-            container,
-            ActivePowerRangeExpressionLB,
-            ActivePowerVariableSlackLB,
-            devices,
-            model,
-            network_model,
-        )
-        add_to_expression!(
-            container,
-            ActivePowerRangeExpressionUB,
-            ActivePowerVariableSlackUB,
-            devices,
-            model,
-            network_model,
         )
     end
 
@@ -1606,31 +1446,15 @@ function construct_device!(
     if get_use_slacks(model)
         add_variables!(
             container,
-            ActivePowerVariableSlackUB,
+            ActivePowerVariableSlackUp,
             devices,
             ThermalCompactUnitCommitment(),
         )
         add_variables!(
             container,
-            ActivePowerVariableSlackLB,
+            ActivePowerVariableSlackDown,
             devices,
             ThermalCompactUnitCommitment(),
-        )
-        add_to_expression!(
-            container,
-            ActivePowerRangeExpressionLB,
-            ActivePowerVariableSlackLB,
-            devices,
-            model,
-            network_model,
-        )
-        add_to_expression!(
-            container,
-            ActivePowerRangeExpressionUB,
-            ActivePowerVariableSlackUB,
-            devices,
-            model,
-            network_model,
         )
     end
 
@@ -1771,31 +1595,15 @@ function construct_device!(
     if get_use_slacks(model)
         add_variables!(
             container,
-            ActivePowerVariableSlackUB,
+            ActivePowerVariableSlackUp,
             devices,
             ThermalCompactUnitCommitment(),
         )
         add_variables!(
             container,
-            ActivePowerVariableSlackLB,
+            ActivePowerVariableSlackDown,
             devices,
             ThermalCompactUnitCommitment(),
-        )
-        add_to_expression!(
-            container,
-            ActivePowerRangeExpressionLB,
-            ActivePowerVariableSlackLB,
-            devices,
-            model,
-            network_model,
-        )
-        add_to_expression!(
-            container,
-            ActivePowerRangeExpressionUB,
-            ActivePowerVariableSlackUB,
-            devices,
-            model,
-            network_model,
         )
     end
     add_feedforward_arguments!(container, model, devices)
@@ -1931,31 +1739,15 @@ function construct_device!(
     if get_use_slacks(model)
         add_variables!(
             container,
-            ActivePowerVariableSlackUB,
+            ActivePowerVariableSlackUp,
             devices,
             ThermalBasicCompactUnitCommitment(),
         )
         add_variables!(
             container,
-            ActivePowerVariableSlackLB,
+            ActivePowerVariableSlackDown,
             devices,
             ThermalBasicCompactUnitCommitment(),
-        )
-        add_to_expression!(
-            container,
-            ActivePowerRangeExpressionLB,
-            ActivePowerVariableSlackLB,
-            devices,
-            model,
-            network_model,
-        )
-        add_to_expression!(
-            container,
-            ActivePowerRangeExpressionUB,
-            ActivePowerVariableSlackUB,
-            devices,
-            model,
-            network_model,
         )
     end
 
@@ -2092,31 +1884,15 @@ function construct_device!(
     if get_use_slacks(model)
         add_variables!(
             container,
-            ActivePowerVariableSlackUB,
+            ActivePowerVariableSlackUp,
             devices,
             ThermalBasicCompactUnitCommitment(),
         )
         add_variables!(
             container,
-            ActivePowerVariableSlackLB,
+            ActivePowerVariableSlackDown,
             devices,
             ThermalBasicCompactUnitCommitment(),
-        )
-        add_to_expression!(
-            container,
-            ActivePowerRangeExpressionLB,
-            ActivePowerVariableSlackLB,
-            devices,
-            model,
-            network_model,
-        )
-        add_to_expression!(
-            container,
-            ActivePowerRangeExpressionUB,
-            ActivePowerVariableSlackUB,
-            devices,
-            model,
-            network_model,
         )
     end
     add_feedforward_arguments!(container, model, devices)
@@ -2246,31 +2022,15 @@ function construct_device!(
     if get_use_slacks(model)
         add_variables!(
             container,
-            ActivePowerVariableSlackUB,
+            ActivePowerVariableSlackUp,
             devices,
             ThermalCompactDispatch(),
         )
         add_variables!(
             container,
-            ActivePowerVariableSlackLB,
+            ActivePowerVariableSlackDown,
             devices,
             ThermalCompactDispatch(),
-        )
-        add_to_expression!(
-            container,
-            ActivePowerRangeExpressionLB,
-            ActivePowerVariableSlackLB,
-            devices,
-            model,
-            network_model,
-        )
-        add_to_expression!(
-            container,
-            ActivePowerRangeExpressionUB,
-            ActivePowerVariableSlackUB,
-            devices,
-            model,
-            network_model,
         )
     end
     return
@@ -2389,31 +2149,15 @@ function construct_device!(
     if get_use_slacks(model)
         add_variables!(
             container,
-            ActivePowerVariableSlackUB,
+            ActivePowerVariableSlackUp,
             devices,
             ThermalCompactDispatch(),
         )
         add_variables!(
             container,
-            ActivePowerVariableSlackLB,
+            ActivePowerVariableSlackDown,
             devices,
             ThermalCompactDispatch(),
-        )
-        add_to_expression!(
-            container,
-            ActivePowerRangeExpressionLB,
-            ActivePowerVariableSlackLB,
-            devices,
-            model,
-            network_model,
-        )
-        add_to_expression!(
-            container,
-            ActivePowerRangeExpressionUB,
-            ActivePowerVariableSlackUB,
-            devices,
-            model,
-            network_model,
         )
     end
     return

--- a/src/devices_models/device_constructors/thermalgeneration_constructor.jl
+++ b/src/devices_models/device_constructors/thermalgeneration_constructor.jl
@@ -108,8 +108,8 @@ function construct_device!(
         model,
     )
     if get_use_slacks(model)
-        add_variables!(container, ActivePowerVariableSlackUp, devices, D())
-        add_variables!(container, ActivePowerVariableSlackDown, devices, D())
+        add_variables!(container, RateofChangeConstraintSlackUp, devices, D())
+        add_variables!(container, RateofChangeConstraintSlackDown, devices, D())
     end
     add_feedforward_arguments!(container, model, devices)
     return
@@ -238,8 +238,8 @@ function construct_device!(
         model,
     )
     if get_use_slacks(model)
-        add_variables!(container, ActivePowerVariableSlackUp, devices, D())
-        add_variables!(container, ActivePowerVariableSlackDown, devices, D())
+        add_variables!(container, RateofChangeConstraintSlackUp, devices, D())
+        add_variables!(container, RateofChangeConstraintSlackDown, devices, D())
     end
 
     add_feedforward_arguments!(container, model, devices)
@@ -369,13 +369,13 @@ function construct_device!(
     if get_use_slacks(model)
         add_variables!(
             container,
-            ActivePowerVariableSlackUp,
+            RateofChangeConstraintSlackUp,
             devices,
             ThermalBasicUnitCommitment(),
         )
         add_variables!(
             container,
-            ActivePowerVariableSlackDown,
+            RateofChangeConstraintSlackDown,
             devices,
             ThermalBasicUnitCommitment(),
         )
@@ -506,13 +506,13 @@ function construct_device!(
     if get_use_slacks(model)
         add_variables!(
             container,
-            ActivePowerVariableSlackUp,
+            RateofChangeConstraintSlackUp,
             devices,
             ThermalBasicUnitCommitment(),
         )
         add_variables!(
             container,
-            ActivePowerVariableSlackDown,
+            RateofChangeConstraintSlackDown,
             devices,
             ThermalBasicUnitCommitment(),
         )
@@ -637,13 +637,13 @@ function construct_device!(
     if get_use_slacks(model)
         add_variables!(
             container,
-            ActivePowerVariableSlackUp,
+            RateofChangeConstraintSlackUp,
             devices,
             ThermalStandardDispatch(),
         )
         add_variables!(
             container,
-            ActivePowerVariableSlackDown,
+            RateofChangeConstraintSlackDown,
             devices,
             ThermalStandardDispatch(),
         )
@@ -757,13 +757,13 @@ function construct_device!(
     if get_use_slacks(model)
         add_variables!(
             container,
-            ActivePowerVariableSlackUp,
+            RateofChangeConstraintSlackUp,
             devices,
             ThermalStandardDispatch(),
         )
         add_variables!(
             container,
-            ActivePowerVariableSlackDown,
+            RateofChangeConstraintSlackDown,
             devices,
             ThermalStandardDispatch(),
         )
@@ -874,8 +874,8 @@ function construct_device!(
         model,
     )
     if get_use_slacks(model)
-        add_variables!(container, ActivePowerVariableSlackUp, devices, D())
-        add_variables!(container, ActivePowerVariableSlackDown, devices, D())
+        add_variables!(container, RateofChangeConstraintSlackUp, devices, D())
+        add_variables!(container, RateofChangeConstraintSlackDown, devices, D())
     end
 
     add_feedforward_arguments!(container, model, devices)
@@ -978,8 +978,8 @@ function construct_device!(
         model,
     )
     if get_use_slacks(model)
-        add_variables!(container, ActivePowerVariableSlackUp, devices, D())
-        add_variables!(container, ActivePowerVariableSlackDown, devices, D())
+        add_variables!(container, RateofChangeConstraintSlackUp, devices, D())
+        add_variables!(container, RateofChangeConstraintSlackDown, devices, D())
     end
 
     add_feedforward_arguments!(container, model, devices)
@@ -1114,13 +1114,13 @@ function construct_device!(
     if get_use_slacks(model)
         add_variables!(
             container,
-            ActivePowerVariableSlackUp,
+            RateofChangeConstraintSlackUp,
             devices,
             ThermalMultiStartUnitCommitment(),
         )
         add_variables!(
             container,
-            ActivePowerVariableSlackDown,
+            RateofChangeConstraintSlackDown,
             devices,
             ThermalMultiStartUnitCommitment(),
         )
@@ -1281,13 +1281,13 @@ function construct_device!(
     if get_use_slacks(model)
         add_variables!(
             container,
-            ActivePowerVariableSlackUp,
+            RateofChangeConstraintSlackUp,
             devices,
             ThermalMultiStartUnitCommitment(),
         )
         add_variables!(
             container,
-            ActivePowerVariableSlackDown,
+            RateofChangeConstraintSlackDown,
             devices,
             ThermalMultiStartUnitCommitment(),
         )
@@ -1446,13 +1446,13 @@ function construct_device!(
     if get_use_slacks(model)
         add_variables!(
             container,
-            ActivePowerVariableSlackUp,
+            RateofChangeConstraintSlackUp,
             devices,
             ThermalCompactUnitCommitment(),
         )
         add_variables!(
             container,
-            ActivePowerVariableSlackDown,
+            RateofChangeConstraintSlackDown,
             devices,
             ThermalCompactUnitCommitment(),
         )
@@ -1595,13 +1595,13 @@ function construct_device!(
     if get_use_slacks(model)
         add_variables!(
             container,
-            ActivePowerVariableSlackUp,
+            RateofChangeConstraintSlackUp,
             devices,
             ThermalCompactUnitCommitment(),
         )
         add_variables!(
             container,
-            ActivePowerVariableSlackDown,
+            RateofChangeConstraintSlackDown,
             devices,
             ThermalCompactUnitCommitment(),
         )
@@ -1739,13 +1739,13 @@ function construct_device!(
     if get_use_slacks(model)
         add_variables!(
             container,
-            ActivePowerVariableSlackUp,
+            RateofChangeConstraintSlackUp,
             devices,
             ThermalBasicCompactUnitCommitment(),
         )
         add_variables!(
             container,
-            ActivePowerVariableSlackDown,
+            RateofChangeConstraintSlackDown,
             devices,
             ThermalBasicCompactUnitCommitment(),
         )
@@ -1884,13 +1884,13 @@ function construct_device!(
     if get_use_slacks(model)
         add_variables!(
             container,
-            ActivePowerVariableSlackUp,
+            RateofChangeConstraintSlackUp,
             devices,
             ThermalBasicCompactUnitCommitment(),
         )
         add_variables!(
             container,
-            ActivePowerVariableSlackDown,
+            RateofChangeConstraintSlackDown,
             devices,
             ThermalBasicCompactUnitCommitment(),
         )
@@ -2022,13 +2022,13 @@ function construct_device!(
     if get_use_slacks(model)
         add_variables!(
             container,
-            ActivePowerVariableSlackUp,
+            RateofChangeConstraintSlackUp,
             devices,
             ThermalCompactDispatch(),
         )
         add_variables!(
             container,
-            ActivePowerVariableSlackDown,
+            RateofChangeConstraintSlackDown,
             devices,
             ThermalCompactDispatch(),
         )
@@ -2149,13 +2149,13 @@ function construct_device!(
     if get_use_slacks(model)
         add_variables!(
             container,
-            ActivePowerVariableSlackUp,
+            RateofChangeConstraintSlackUp,
             devices,
             ThermalCompactDispatch(),
         )
         add_variables!(
             container,
-            ActivePowerVariableSlackDown,
+            RateofChangeConstraintSlackDown,
             devices,
             ThermalCompactDispatch(),
         )

--- a/src/devices_models/devices/common/add_to_expression.jl
+++ b/src/devices_models/devices/common/add_to_expression.jl
@@ -1238,6 +1238,33 @@ function add_to_expression!(
     container::OptimizationContainer,
     ::Type{T},
     ::Type{U},
+    devices::IS.FlattenIteratorWrapper{V},
+    model::DeviceModel{V, W},
+    network_model::NetworkModel{X},
+) where {
+    T <: Union{ActivePowerRangeExpressionUB, ActivePowerRangeExpressionLB},
+    U <: Union{ActivePowerVariableSlackUB, ActivePowerVariableSlackLB},
+    V <: PSY.Device,
+    W <: AbstractDeviceFormulation,
+    X <: PM.AbstractPowerModel,
+}
+    variable = get_variable(container, U(), V)
+    if !has_container_key(container, T, V)
+        add_expressions!(container, T, devices, model)
+    end
+    expression = get_expression(container, T(), V)
+    for d in devices, t in get_time_steps(container)
+        mult = get_expression_multiplier(U(), T(), d, W())
+        name = PSY.get_name(d)
+        _add_to_jump_expression!(expression[name, t], variable[name, t], mult)
+    end
+    return
+end
+
+function add_to_expression!(
+    container::OptimizationContainer,
+    ::Type{T},
+    ::Type{U},
     devices::Union{Vector{V}, IS.FlattenIteratorWrapper{V}},
     model::ServiceModel{X, W},
 ) where {

--- a/src/devices_models/devices/common/add_to_expression.jl
+++ b/src/devices_models/devices/common/add_to_expression.jl
@@ -1238,33 +1238,6 @@ function add_to_expression!(
     container::OptimizationContainer,
     ::Type{T},
     ::Type{U},
-    devices::IS.FlattenIteratorWrapper{V},
-    model::DeviceModel{V, W},
-    network_model::NetworkModel{X},
-) where {
-    T <: Union{ActivePowerRangeExpressionUB, ActivePowerRangeExpressionLB},
-    U <: Union{ActivePowerVariableSlackUB, ActivePowerVariableSlackLB},
-    V <: PSY.Device,
-    W <: AbstractDeviceFormulation,
-    X <: PM.AbstractPowerModel,
-}
-    variable = get_variable(container, U(), V)
-    if !has_container_key(container, T, V)
-        add_expressions!(container, T, devices, model)
-    end
-    expression = get_expression(container, T(), V)
-    for d in devices, t in get_time_steps(container)
-        mult = get_expression_multiplier(U(), T(), d, W())
-        name = PSY.get_name(d)
-        _add_to_jump_expression!(expression[name, t], variable[name, t], mult)
-    end
-    return
-end
-
-function add_to_expression!(
-    container::OptimizationContainer,
-    ::Type{T},
-    ::Type{U},
     devices::Union{Vector{V}, IS.FlattenIteratorWrapper{V}},
     model::ServiceModel{X, W},
 ) where {

--- a/src/devices_models/devices/common/rateofchange_constraints.jl
+++ b/src/devices_models/devices/common/rateofchange_constraints.jl
@@ -40,8 +40,8 @@ function _get_ramp_slack_vars(
     t::Int,
 ) where {V <: PSY.Component, W <: AbstractDeviceFormulation}
     if get_use_slacks(model)
-        slack_ub = get_variable(container, ActivePowerVariableSlackUp(), V)
-        slack_lb = get_variable(container, ActivePowerVariableSlackDown(), V)
+        slack_ub = get_variable(container, RateofChangeConstraintSlackUp(), V)
+        slack_lb = get_variable(container, RateofChangeConstraintSlackDown(), V)
         sl_ub = slack_ub[name, t]
         sl_lb = slack_lb[name, t]
     else

--- a/src/devices_models/devices/common/rateofchange_constraints.jl
+++ b/src/devices_models/devices/common/rateofchange_constraints.jl
@@ -119,7 +119,7 @@ function add_linear_ramp_constraints!(
             -1 * ramp_limits.down * minutes_per_period
         )
         for t in time_steps[2:end]
-            sl_ub, sl_lb = _get_ramp_slack_vals(model, name, t)
+            sl_ub, sl_lb = _get_ramp_slack_vars(container, model, name, t)
             con_up[name, t] = JuMP.@constraint(
                 get_jump_model(container),
                 expr_up[name, t] - variable[name, t - 1] - sl_ub <=

--- a/src/devices_models/devices/thermal_generation.jl
+++ b/src/devices_models/devices/thermal_generation.jl
@@ -51,11 +51,11 @@ get_variable_binary(::Union{ColdStartVariable, WarmStartVariable, HotStartVariab
 
 ############## SlackVariables, ThermalGen ####################
 # LB Slack #
-get_variable_binary(::ActivePowerVariableSlackDown, ::Type{<:PSY.ThermalGen}, ::AbstractThermalFormulation) = false
-get_variable_lower_bound(::ActivePowerVariableSlackDown, d::PSY.ThermalGen, ::AbstractThermalFormulation) = 0.0
+get_variable_binary(::RateofChangeConstraintSlackDown, ::Type{<:PSY.ThermalGen}, ::AbstractThermalFormulation) = false
+get_variable_lower_bound(::RateofChangeConstraintSlackDown, d::PSY.ThermalGen, ::AbstractThermalFormulation) = 0.0
 # UB Slack #
-get_variable_binary(::ActivePowerVariableSlackUp, ::Type{<:PSY.ThermalGen}, ::AbstractThermalFormulation) = false
-get_variable_lower_bound(::ActivePowerVariableSlackUp, d::PSY.ThermalGen, ::AbstractThermalFormulation) = 0.0
+get_variable_binary(::RateofChangeConstraintSlackUp, ::Type{<:PSY.ThermalGen}, ::AbstractThermalFormulation) = false
+get_variable_lower_bound(::RateofChangeConstraintSlackUp, d::PSY.ThermalGen, ::AbstractThermalFormulation) = 0.0
 
 
 ########################### Parameter related set functions ################################
@@ -92,7 +92,7 @@ end
 
 proportional_cost(cost::PSY.MarketBidCost, ::OnVariable, ::PSY.ThermalGen, ::AbstractThermalFormulation) = PSY.get_no_load_cost(cost)
 
-proportional_cost(::Union{PSY.MarketBidCost, PSY.ThermalGenerationCost}, ::Union{ActivePowerVariableSlackUp, ActivePowerVariableSlackDown}, ::PSY.ThermalGen, ::AbstractThermalFormulation) = CONSTRAINT_VIOLATION_SLACK_COST
+proportional_cost(::Union{PSY.MarketBidCost, PSY.ThermalGenerationCost}, ::Union{RateofChangeConstraintSlackUp, RateofChangeConstraintSlackDown}, ::PSY.ThermalGen, ::AbstractThermalFormulation) = CONSTRAINT_VIOLATION_SLACK_COST
 
 
 has_multistart_variables(::PSY.ThermalGen, ::AbstractThermalFormulation)=false
@@ -1450,8 +1450,8 @@ function objective_function!(
     add_shut_down_cost!(container, StopVariable(), devices, U())
     add_proportional_cost!(container, OnVariable(), devices, U())
     if get_use_slacks(model)
-        add_proportional_cost!(container, ActivePowerVariableSlackUp(), devices, U())
-        add_proportional_cost!(container, ActivePowerVariableSlackDown(), devices, U())
+        add_proportional_cost!(container, RateofChangeConstraintSlackUp(), devices, U())
+        add_proportional_cost!(container, RateofChangeConstraintSlackDown(), devices, U())
     end
     return
 end
@@ -1467,8 +1467,8 @@ function objective_function!(
     add_shut_down_cost!(container, StopVariable(), devices, U())
     add_proportional_cost!(container, OnVariable(), devices, U())
     if get_use_slacks(model)
-        add_proportional_cost!(container, ActivePowerVariableSlackUp(), devices, U())
-        add_proportional_cost!(container, ActivePowerVariableSlackDown(), devices, U())
+        add_proportional_cost!(container, RateofChangeConstraintSlackUp(), devices, U())
+        add_proportional_cost!(container, RateofChangeConstraintSlackDown(), devices, U())
     end
     return
 end
@@ -1486,8 +1486,8 @@ function objective_function!(
     add_shut_down_cost!(container, StopVariable(), devices, U())
     add_proportional_cost!(container, OnVariable(), devices, U())
     if get_use_slacks(model)
-        add_proportional_cost!(container, ActivePowerVariableSlackUp(), devices, U())
-        add_proportional_cost!(container, ActivePowerVariableSlackDown(), devices, U())
+        add_proportional_cost!(container, RateofChangeConstraintSlackUp(), devices, U())
+        add_proportional_cost!(container, RateofChangeConstraintSlackDown(), devices, U())
     end
     return
 end
@@ -1500,8 +1500,8 @@ function objective_function!(
 ) where {T <: PSY.ThermalGen, U <: AbstractThermalDispatchFormulation}
     add_variable_cost!(container, ActivePowerVariable(), devices, U())
     if get_use_slacks(model)
-        add_proportional_cost!(container, ActivePowerVariableSlackUp(), devices, U())
-        add_proportional_cost!(container, ActivePowerVariableSlackDown(), devices, U())
+        add_proportional_cost!(container, RateofChangeConstraintSlackUp(), devices, U())
+        add_proportional_cost!(container, RateofChangeConstraintSlackDown(), devices, U())
     end
     return
 end
@@ -1514,8 +1514,8 @@ function objective_function!(
 ) where {T <: PSY.ThermalGen, U <: ThermalCompactDispatch}
     add_variable_cost!(container, PowerAboveMinimumVariable(), devices, U())
     if get_use_slacks(model)
-        add_proportional_cost!(container, ActivePowerVariableSlackUp(), devices, U())
-        add_proportional_cost!(container, ActivePowerVariableSlackDown(), devices, U())
+        add_proportional_cost!(container, RateofChangeConstraintSlackUp(), devices, U())
+        add_proportional_cost!(container, RateofChangeConstraintSlackDown(), devices, U())
     end
     return
 end

--- a/src/devices_models/devices/thermal_generation.jl
+++ b/src/devices_models/devices/thermal_generation.jl
@@ -51,13 +51,11 @@ get_variable_binary(::Union{ColdStartVariable, WarmStartVariable, HotStartVariab
 
 ############## SlackVariables, ThermalGen ####################
 # LB Slack #
-get_variable_binary(::ActivePowerVariableSlackLB, ::Type{<:PSY.ThermalGen}, ::AbstractThermalFormulation) = false
-get_variable_lower_bound(::ActivePowerVariableSlackLB, d::PSY.ThermalGen, ::AbstractThermalFormulation) = 0.0
-get_expression_multiplier(::ActivePowerVariableSlackLB, ::ActivePowerRangeExpressionLB, d::PSY.ThermalGen, ::AbstractThermalFormulation) = 1.0
+get_variable_binary(::ActivePowerVariableSlackDown, ::Type{<:PSY.ThermalGen}, ::AbstractThermalFormulation) = false
+get_variable_lower_bound(::ActivePowerVariableSlackDown, d::PSY.ThermalGen, ::AbstractThermalFormulation) = 0.0
 # UB Slack #
-get_variable_binary(::ActivePowerVariableSlackUB, ::Type{<:PSY.ThermalGen}, ::AbstractThermalFormulation) = false
-get_variable_lower_bound(::ActivePowerVariableSlackUB, d::PSY.ThermalGen, ::AbstractThermalFormulation) = 0.0
-get_expression_multiplier(::ActivePowerVariableSlackUB, ::ActivePowerRangeExpressionUB, d::PSY.ThermalGen, ::AbstractThermalFormulation) = -1.0
+get_variable_binary(::ActivePowerVariableSlackUp, ::Type{<:PSY.ThermalGen}, ::AbstractThermalFormulation) = false
+get_variable_lower_bound(::ActivePowerVariableSlackUp, d::PSY.ThermalGen, ::AbstractThermalFormulation) = 0.0
 
 
 ########################### Parameter related set functions ################################
@@ -94,7 +92,7 @@ end
 
 proportional_cost(cost::PSY.MarketBidCost, ::OnVariable, ::PSY.ThermalGen, ::AbstractThermalFormulation) = PSY.get_no_load_cost(cost)
 
-proportional_cost(::Union{PSY.MarketBidCost, PSY.ThermalGenerationCost}, ::Union{ActivePowerVariableSlackUB, ActivePowerVariableSlackLB}, ::PSY.ThermalGen, ::AbstractThermalFormulation) = CONSTRAINT_VIOLATION_SLACK_COST
+proportional_cost(::Union{PSY.MarketBidCost, PSY.ThermalGenerationCost}, ::Union{ActivePowerVariableSlackUp, ActivePowerVariableSlackDown}, ::PSY.ThermalGen, ::AbstractThermalFormulation) = CONSTRAINT_VIOLATION_SLACK_COST
 
 
 has_multistart_variables(::PSY.ThermalGen, ::AbstractThermalFormulation)=false
@@ -1452,8 +1450,8 @@ function objective_function!(
     add_shut_down_cost!(container, StopVariable(), devices, U())
     add_proportional_cost!(container, OnVariable(), devices, U())
     if get_use_slacks(model)
-        add_proportional_cost!(container, ActivePowerVariableSlackUB(), devices, U())
-        add_proportional_cost!(container, ActivePowerVariableSlackLB(), devices, U())
+        add_proportional_cost!(container, ActivePowerVariableSlackUp(), devices, U())
+        add_proportional_cost!(container, ActivePowerVariableSlackDown(), devices, U())
     end
     return
 end
@@ -1469,8 +1467,8 @@ function objective_function!(
     add_shut_down_cost!(container, StopVariable(), devices, U())
     add_proportional_cost!(container, OnVariable(), devices, U())
     if get_use_slacks(model)
-        add_proportional_cost!(container, ActivePowerVariableSlackUB(), devices, U())
-        add_proportional_cost!(container, ActivePowerVariableSlackLB(), devices, U())
+        add_proportional_cost!(container, ActivePowerVariableSlackUp(), devices, U())
+        add_proportional_cost!(container, ActivePowerVariableSlackDown(), devices, U())
     end
     return
 end
@@ -1488,8 +1486,8 @@ function objective_function!(
     add_shut_down_cost!(container, StopVariable(), devices, U())
     add_proportional_cost!(container, OnVariable(), devices, U())
     if get_use_slacks(model)
-        add_proportional_cost!(container, ActivePowerVariableSlackUB(), devices, U())
-        add_proportional_cost!(container, ActivePowerVariableSlackLB(), devices, U())
+        add_proportional_cost!(container, ActivePowerVariableSlackUp(), devices, U())
+        add_proportional_cost!(container, ActivePowerVariableSlackDown(), devices, U())
     end
     return
 end
@@ -1502,8 +1500,8 @@ function objective_function!(
 ) where {T <: PSY.ThermalGen, U <: AbstractThermalDispatchFormulation}
     add_variable_cost!(container, ActivePowerVariable(), devices, U())
     if get_use_slacks(model)
-        add_proportional_cost!(container, ActivePowerVariableSlackUB(), devices, U())
-        add_proportional_cost!(container, ActivePowerVariableSlackLB(), devices, U())
+        add_proportional_cost!(container, ActivePowerVariableSlackUp(), devices, U())
+        add_proportional_cost!(container, ActivePowerVariableSlackDown(), devices, U())
     end
     return
 end
@@ -1516,8 +1514,8 @@ function objective_function!(
 ) where {T <: PSY.ThermalGen, U <: ThermalCompactDispatch}
     add_variable_cost!(container, PowerAboveMinimumVariable(), devices, U())
     if get_use_slacks(model)
-        add_proportional_cost!(container, ActivePowerVariableSlackUB(), devices, U())
-        add_proportional_cost!(container, ActivePowerVariableSlackLB(), devices, U())
+        add_proportional_cost!(container, ActivePowerVariableSlackUp(), devices, U())
+        add_proportional_cost!(container, ActivePowerVariableSlackDown(), devices, U())
     end
     return
 end

--- a/src/devices_models/devices/thermal_generation.jl
+++ b/src/devices_models/devices/thermal_generation.jl
@@ -49,6 +49,17 @@ get_variable_upper_bound(::StartVariable, d::PSY.ThermalGen, ::AbstractThermalFo
 ############## ColdStartVariable, WarmStartVariable, HotStartVariable ############
 get_variable_binary(::Union{ColdStartVariable, WarmStartVariable, HotStartVariable}, ::Type{PSY.ThermalMultiStart}, ::AbstractThermalFormulation) = true
 
+############## SlackVariables, ThermalGen ####################
+# LB Slack #
+get_variable_binary(::ActivePowerVariableSlackLB, ::Type{<:PSY.ThermalGen}, ::AbstractThermalFormulation) = false
+get_variable_lower_bound(::ActivePowerVariableSlackLB, d::PSY.ThermalGen, ::AbstractThermalFormulation) = 0.0
+get_expression_multiplier(::ActivePowerVariableSlackLB, ::ActivePowerRangeExpressionLB, d::PSY.ThermalGen, ::AbstractThermalFormulation) = 1.0
+# UB Slack #
+get_variable_binary(::ActivePowerVariableSlackUB, ::Type{<:PSY.ThermalGen}, ::AbstractThermalFormulation) = false
+get_variable_lower_bound(::ActivePowerVariableSlackUB, d::PSY.ThermalGen, ::AbstractThermalFormulation) = 0.0
+get_expression_multiplier(::ActivePowerVariableSlackUB, ::ActivePowerRangeExpressionUB, d::PSY.ThermalGen, ::AbstractThermalFormulation) = -1.0
+
+
 ########################### Parameter related set functions ################################
 get_multiplier_value(::ActivePowerTimeSeriesParameter, d::PSY.ThermalGen, ::AbstractThermalFormulation) = PSY.get_max_active_power(d)
 get_multiplier_value(::FuelCostParameter, d::PSY.ThermalGen, ::AbstractThermalFormulation) = 1.0
@@ -82,6 +93,9 @@ function proportional_cost(container::OptimizationContainer, cost::PSY.ThermalGe
 end
 
 proportional_cost(cost::PSY.MarketBidCost, ::OnVariable, ::PSY.ThermalGen, ::AbstractThermalFormulation) = PSY.get_no_load_cost(cost)
+
+proportional_cost(::Union{PSY.MarketBidCost, PSY.ThermalGenerationCost}, ::Union{ActivePowerVariableSlackUB, ActivePowerVariableSlackLB}, ::PSY.ThermalGen, ::AbstractThermalFormulation) = CONSTRAINT_VIOLATION_SLACK_COST
+
 
 has_multistart_variables(::PSY.ThermalGen, ::AbstractThermalFormulation)=false
 has_multistart_variables(::PSY.ThermalMultiStart, ::ThermalMultiStartUnitCommitment)=true
@@ -1430,33 +1444,41 @@ end
 function objective_function!(
     container::OptimizationContainer,
     devices::IS.FlattenIteratorWrapper{T},
-    ::DeviceModel{T, U},
+    model::DeviceModel{T, U},
     ::Type{<:PM.AbstractPowerModel},
 ) where {T <: PSY.ThermalGen, U <: AbstractThermalUnitCommitment}
     add_variable_cost!(container, ActivePowerVariable(), devices, U())
     add_start_up_cost!(container, StartVariable(), devices, U())
     add_shut_down_cost!(container, StopVariable(), devices, U())
     add_proportional_cost!(container, OnVariable(), devices, U())
+    if get_use_slacks(model)
+        add_proportional_cost!(container, ActivePowerVariableSlackUB(), devices, U())
+        add_proportional_cost!(container, ActivePowerVariableSlackLB(), devices, U())
+    end
     return
 end
 
 function objective_function!(
     container::OptimizationContainer,
     devices::IS.FlattenIteratorWrapper{T},
-    ::DeviceModel{T, U},
+    model::DeviceModel{T, U},
     ::Type{<:PM.AbstractPowerModel},
 ) where {T <: PSY.ThermalGen, U <: AbstractCompactUnitCommitment}
     add_variable_cost!(container, PowerAboveMinimumVariable(), devices, U())
     add_start_up_cost!(container, StartVariable(), devices, U())
     add_shut_down_cost!(container, StopVariable(), devices, U())
     add_proportional_cost!(container, OnVariable(), devices, U())
+    if get_use_slacks(model)
+        add_proportional_cost!(container, ActivePowerVariableSlackUB(), devices, U())
+        add_proportional_cost!(container, ActivePowerVariableSlackLB(), devices, U())
+    end
     return
 end
 
 function objective_function!(
     container::OptimizationContainer,
     devices::IS.FlattenIteratorWrapper{PSY.ThermalMultiStart},
-    ::DeviceModel{PSY.ThermalMultiStart, U},
+    model::DeviceModel{PSY.ThermalMultiStart, U},
     ::Type{<:PM.AbstractPowerModel},
 ) where {U <: ThermalMultiStartUnitCommitment}
     add_variable_cost!(container, PowerAboveMinimumVariable(), devices, U())
@@ -1465,26 +1487,38 @@ function objective_function!(
     end
     add_shut_down_cost!(container, StopVariable(), devices, U())
     add_proportional_cost!(container, OnVariable(), devices, U())
+    if get_use_slacks(model)
+        add_proportional_cost!(container, ActivePowerVariableSlackUB(), devices, U())
+        add_proportional_cost!(container, ActivePowerVariableSlackLB(), devices, U())
+    end
     return
 end
 
 function objective_function!(
     container::OptimizationContainer,
     devices::IS.FlattenIteratorWrapper{T},
-    ::DeviceModel{T, U},
+    model::DeviceModel{T, U},
     ::Type{<:PM.AbstractPowerModel},
 ) where {T <: PSY.ThermalGen, U <: AbstractThermalDispatchFormulation}
     add_variable_cost!(container, ActivePowerVariable(), devices, U())
+    if get_use_slacks(model)
+        add_proportional_cost!(container, ActivePowerVariableSlackUB(), devices, U())
+        add_proportional_cost!(container, ActivePowerVariableSlackLB(), devices, U())
+    end
     return
 end
 
 function objective_function!(
     container::OptimizationContainer,
     devices::IS.FlattenIteratorWrapper{T},
-    ::DeviceModel{T, U},
+    model::DeviceModel{T, U},
     ::Type{<:PM.AbstractPowerModel},
 ) where {T <: PSY.ThermalGen, U <: ThermalCompactDispatch}
     add_variable_cost!(container, PowerAboveMinimumVariable(), devices, U())
+    if get_use_slacks(model)
+        add_proportional_cost!(container, ActivePowerVariableSlackUB(), devices, U())
+        add_proportional_cost!(container, ActivePowerVariableSlackLB(), devices, U())
+    end
     return
 end
 

--- a/src/devices_models/devices/thermal_generation.jl
+++ b/src/devices_models/devices/thermal_generation.jl
@@ -1442,14 +1442,14 @@ end
 function objective_function!(
     container::OptimizationContainer,
     devices::IS.FlattenIteratorWrapper{T},
-    model::DeviceModel{T, U},
+    device_model::DeviceModel{T, U},
     ::Type{<:PM.AbstractPowerModel},
 ) where {T <: PSY.ThermalGen, U <: AbstractThermalUnitCommitment}
     add_variable_cost!(container, ActivePowerVariable(), devices, U())
     add_start_up_cost!(container, StartVariable(), devices, U())
     add_shut_down_cost!(container, StopVariable(), devices, U())
     add_proportional_cost!(container, OnVariable(), devices, U())
-    if get_use_slacks(model)
+    if get_use_slacks(device_model)
         add_proportional_cost!(container, RateofChangeConstraintSlackUp(), devices, U())
         add_proportional_cost!(container, RateofChangeConstraintSlackDown(), devices, U())
     end
@@ -1459,14 +1459,14 @@ end
 function objective_function!(
     container::OptimizationContainer,
     devices::IS.FlattenIteratorWrapper{T},
-    model::DeviceModel{T, U},
+    device_model::DeviceModel{T, U},
     ::Type{<:PM.AbstractPowerModel},
 ) where {T <: PSY.ThermalGen, U <: AbstractCompactUnitCommitment}
     add_variable_cost!(container, PowerAboveMinimumVariable(), devices, U())
     add_start_up_cost!(container, StartVariable(), devices, U())
     add_shut_down_cost!(container, StopVariable(), devices, U())
     add_proportional_cost!(container, OnVariable(), devices, U())
-    if get_use_slacks(model)
+    if get_use_slacks(device_model)
         add_proportional_cost!(container, RateofChangeConstraintSlackUp(), devices, U())
         add_proportional_cost!(container, RateofChangeConstraintSlackDown(), devices, U())
     end
@@ -1476,7 +1476,7 @@ end
 function objective_function!(
     container::OptimizationContainer,
     devices::IS.FlattenIteratorWrapper{PSY.ThermalMultiStart},
-    model::DeviceModel{PSY.ThermalMultiStart, U},
+    device_model::DeviceModel{PSY.ThermalMultiStart, U},
     ::Type{<:PM.AbstractPowerModel},
 ) where {U <: ThermalMultiStartUnitCommitment}
     add_variable_cost!(container, PowerAboveMinimumVariable(), devices, U())
@@ -1485,7 +1485,7 @@ function objective_function!(
     end
     add_shut_down_cost!(container, StopVariable(), devices, U())
     add_proportional_cost!(container, OnVariable(), devices, U())
-    if get_use_slacks(model)
+    if get_use_slacks(device_model)
         add_proportional_cost!(container, RateofChangeConstraintSlackUp(), devices, U())
         add_proportional_cost!(container, RateofChangeConstraintSlackDown(), devices, U())
     end
@@ -1495,11 +1495,11 @@ end
 function objective_function!(
     container::OptimizationContainer,
     devices::IS.FlattenIteratorWrapper{T},
-    model::DeviceModel{T, U},
+    device_model::DeviceModel{T, U},
     ::Type{<:PM.AbstractPowerModel},
 ) where {T <: PSY.ThermalGen, U <: AbstractThermalDispatchFormulation}
     add_variable_cost!(container, ActivePowerVariable(), devices, U())
-    if get_use_slacks(model)
+    if get_use_slacks(device_model)
         add_proportional_cost!(container, RateofChangeConstraintSlackUp(), devices, U())
         add_proportional_cost!(container, RateofChangeConstraintSlackDown(), devices, U())
     end
@@ -1509,11 +1509,11 @@ end
 function objective_function!(
     container::OptimizationContainer,
     devices::IS.FlattenIteratorWrapper{T},
-    model::DeviceModel{T, U},
+    device_model::DeviceModel{T, U},
     ::Type{<:PM.AbstractPowerModel},
 ) where {T <: PSY.ThermalGen, U <: ThermalCompactDispatch}
     add_variable_cost!(container, PowerAboveMinimumVariable(), devices, U())
-    if get_use_slacks(model)
+    if get_use_slacks(device_model)
         add_proportional_cost!(container, RateofChangeConstraintSlackUp(), devices, U())
         add_proportional_cost!(container, RateofChangeConstraintSlackDown(), devices, U())
     end

--- a/test/test_device_thermal_generation_constructors.jl
+++ b/test/test_device_thermal_generation_constructors.jl
@@ -1103,6 +1103,7 @@ end
         PSI.AuxVarKey(PSI.TimeDurationOff, ThermalStandard),
         PSI.AuxVarKey(PSI.TimeDurationOn, ThermalStandard),
     ]
+    # Unit Commitment #
     device_model =
         DeviceModel(ThermalStandard, ThermalStandardUnitCommitment; use_slacks = true)
 
@@ -1120,5 +1121,26 @@ end
     mock_construct_device!(model, device_model)
     moi_tests(model, 720, 0, 240, 120, 120, true)
     psi_checkbinvar_test(model, bin_variable_keys)
+    psi_checkobjfun_test(model, GQEVF)
+
+    # Dispatch #
+    device_model =
+        DeviceModel(ThermalStandard, ThermalStandardDispatch; use_slacks = true)
+    uc_constraint_keys = [
+        PSI.ConstraintKey(RampConstraint, PSY.ThermalStandard, "up"),
+        PSI.ConstraintKey(RampConstraint, PSY.ThermalStandard, "dn"),
+    ]
+
+    c_sys5_uc = PSB.build_system(PSITestSystems, "c_sys5_uc")
+    model = DecisionModel(MockOperationProblem, DCPPowerModel, c_sys5_uc)
+    mock_construct_device!(model, device_model)
+    moi_tests(model, 360, 0, 168, 168, 0, false)
+    psi_constraint_test(model, uc_constraint_keys)
+    psi_checkobjfun_test(model, GAEVF)
+
+    c_sys14 = PSB.build_system(PSITestSystems, "c_sys14")
+    model = DecisionModel(MockOperationProblem, DCPPowerModel, c_sys14)
+    mock_construct_device!(model, device_model)
+    moi_tests(model, 360, 0, 120, 120, 0, false)
     psi_checkobjfun_test(model, GQEVF)
 end

--- a/test/test_device_thermal_generation_constructors.jl
+++ b/test/test_device_thermal_generation_constructors.jl
@@ -1084,3 +1084,41 @@ end
         JuMP.QuadExpr,
     )
 end
+
+@testset "Thermal UC With Slack on Ramps" begin
+    bin_variable_keys = [
+        PSI.VariableKey(OnVariable, PSY.ThermalStandard),
+        PSI.VariableKey(StartVariable, PSY.ThermalStandard),
+        PSI.VariableKey(StopVariable, PSY.ThermalStandard),
+    ]
+
+    uc_constraint_keys = [
+        PSI.ConstraintKey(RampConstraint, PSY.ThermalStandard, "up"),
+        PSI.ConstraintKey(RampConstraint, PSY.ThermalStandard, "dn"),
+        PSI.ConstraintKey(DurationConstraint, PSY.ThermalStandard, "up"),
+        PSI.ConstraintKey(DurationConstraint, PSY.ThermalStandard, "dn"),
+    ]
+
+    aux_variables_keys = [
+        PSI.AuxVarKey(PSI.TimeDurationOff, ThermalStandard),
+        PSI.AuxVarKey(PSI.TimeDurationOn, ThermalStandard),
+    ]
+    device_model =
+        DeviceModel(ThermalStandard, ThermalStandardUnitCommitment; use_slacks = true)
+
+    c_sys5_uc = PSB.build_system(PSITestSystems, "c_sys5_uc")
+    model = DecisionModel(MockOperationProblem, DCPPowerModel, c_sys5_uc)
+    mock_construct_device!(model, device_model)
+    moi_tests(model, 720, 0, 480, 120, 120, true)
+    psi_constraint_test(model, uc_constraint_keys)
+    psi_checkbinvar_test(model, bin_variable_keys)
+    psi_checkobjfun_test(model, GAEVF)
+    psi_aux_variable_test(model, aux_variables_keys)
+
+    c_sys14 = PSB.build_system(PSITestSystems, "c_sys14")
+    model = DecisionModel(MockOperationProblem, DCPPowerModel, c_sys14)
+    mock_construct_device!(model, device_model)
+    moi_tests(model, 720, 0, 240, 120, 120, true)
+    psi_checkbinvar_test(model, bin_variable_keys)
+    psi_checkobjfun_test(model, GQEVF)
+end


### PR DESCRIPTION
Closes #1204 

Add slacks for UB and LB constraints for thermal units. It uses the `use_slacks` of the device model, so to enable, using:

```
thermal_device_model = DeviceModel(
    ThermalStandard,
    ThermalStandardUnitCommitment;
    use_slacks = true,
)
set_device_model!(template_uc, thermal_device_model)
```
will enable the slacks.

The slack variables are added to the objective function with a cost of `2e5`, using the constraint violation cost.

Here is how it looks for a RampConstraint UB:
```
-ActivePowerVariable_ThermalStandard_{107_CC_1, 1} + ActivePowerVariable_ThermalStandard_{107_CC_1, 2} - 1.6999999999999997 StartVariable_ThermalStandard_{107_CC_1, 2} - PowerSimulations.ActivePowerVariableSlackUB_ThermalStandard_{107_CC_1, 2} + ActivePowerReserveVariable_VariableReserve{ReserveUp}_Spin_Up_R1_{107_CC_1, 2} + ActivePowerReserveVariable_VariableReserve{ReserveUp}_Reg_Up_{107_CC_1, 2} ≤ 0.20699999999999996
```
and for a RampConstraint LB:
```
ActivePowerVariable_ThermalStandard_{107_CC_1, 1} - ActivePowerVariable_ThermalStandard_{107_CC_1, 2} - 1.6999999999999997 StopVariable_ThermalStandard_{107_CC_1, 2} - PowerSimulations.ActivePowerVariableSlackLB_ThermalStandard_{107_CC_1, 2} + ActivePowerReserveVariable_VariableReserve{ReserveDown}_Reg_Down_{107_CC_1, 2} ≤ 0.20699999999999996
```


TODO: 
- [ ] Tests