### PR TITLE
Mb/cross horizon outages

### DIFF
--- a/src/PowerSimulations.jl
+++ b/src/PowerSimulations.jl
@@ -320,7 +320,7 @@ export FixValueParameter
 
 # Event Parameters
 export AvailableStatusParameter
-export AvailableStatusChangeParameter
+export AvailableStatusChangeCountdownParameter
 
 # Expressions
 export SystemBalanceExpressions

--- a/src/contingency_model/contingency.jl
+++ b/src/contingency_model/contingency.jl
@@ -2,6 +2,6 @@
 get_parameter_type(::Type{<:PSY.Outage}, ::EventModel, ::Type{<:PSY.Device}) = AvailableStatusParameter
 # This value could change depending on the event modeling choices
 get_parameter_multiplier(::EventParameter, ::PSY.Device, ::EventModel) = 1.0
-get_initial_parameter_value(::AvailableStatusChangeParameter, ::PSY.Device, ::EventModel) = 0.0
+get_initial_parameter_value(::AvailableStatusChangeCountdownParameter, ::PSY.Device, ::EventModel) = 0.0
 get_initial_parameter_value(::AvailableStatusParameter, ::PSY.Device, ::EventModel) = 1.0
 #! format: on

--- a/src/contingency_model/contingency_arguments.jl
+++ b/src/contingency_model/contingency_arguments.jl
@@ -13,7 +13,7 @@ function add_event_arguments!(
             [d for d in devices if PSY.has_supplemental_attributes(d, event_type)]
         @assert !isempty(devices_with_attrbts)
         parameter_type = get_parameter_type(event_type, event_model, U)
-        for p_type in [AvailableStatusChangeParameter, parameter_type]
+        for p_type in [AvailableStatusChangeCountdownParameter, parameter_type]
             add_parameters!(
                 container,
                 p_type,

--- a/src/core/event_model.jl
+++ b/src/core/event_model.jl
@@ -68,20 +68,40 @@ get_condition_function(c::DiscreteEventCondition) = c.condition_function
 
 mutable struct EventModel{D <: PSY.Contingency, B <: AbstractEventCondition}
     condition::B
+    timeseries_mapping::Dict{Symbol, Union{String, Nothing}}
     attribute_device_map::Dict{Symbol, Dict{Base.UUID, Dict{DataType, Set{String}}}}
     attributes::Dict{String, Any}
 
     function EventModel(
-        ::Type{D},
+        contingency_type::Type{D},
         condition::B;
+        timeseries_mapping = get_empty_timeseries_mapping(contingency_type),
         attributes = Dict{String, Any}(),
     ) where {D <: PSY.Contingency, B <: AbstractEventCondition}
         new{D, B}(
             condition,
+            timeseries_mapping,
             Dict{Symbol, Dict{Base.UUID, Dict{DataType, Set{String}}}}(),
             attributes,
         )
     end
+end
+
+function get_empty_timeseries_mapping(
+    ::Type{PSY.TimeSeriesForcedOutage},
+) where {D <: PSY.Contingency}
+    return Dict{Symbol, Union{String, Nothing}}(
+        :availability => nothing,
+    )
+end
+
+function get_empty_timeseries_mapping(
+    ::Type{PSY.GeometricDistributionForcedOutage},
+) where {D <: PSY.Contingency}
+    return Dict{Symbol, Union{String, Nothing}}(
+        :mean_time_to_recovery => nothing,
+        :outage_transition_probability => nothing,
+    )
 end
 
 get_event_type(

--- a/src/core/parameters.jl
+++ b/src/core/parameters.jl
@@ -166,8 +166,6 @@ function get_parameter_values(
     param_array::DenseAxisArray,
     multiplier_array::DenseAxisArray,
 )
-    @error "$attr"
-    @show jump_value.(param_array)
     return jump_value.(param_array)
 end
 

--- a/src/core/parameters.jl
+++ b/src/core/parameters.jl
@@ -342,7 +342,7 @@ struct AvailableStatusParameter <: EventParameter end
 """
 Parameter to record that the component changed in the availability status
 """
-struct AvailableStatusChangeParameter <: EventParameter end
+struct AvailableStatusChangeCountdownParameter <: EventParameter end
 
 should_write_resulting_value(::Type{<:RightHandSideParameter}) = true
 should_write_resulting_value(::Type{<:EventParameter}) = true

--- a/src/parameters/update_container_parameter_values.jl
+++ b/src/parameters/update_container_parameter_values.jl
@@ -390,7 +390,7 @@ function _update_parameter_values!(
                      Consider reviewing your models' horizon and interval definitions",
                 )
             end
-            if 0.0 > value 
+            if 0.0 > value
                 error(
                     "The value for the system state used in $(encode_key_as_string(get_attribute_key(attributes))): $(value) is less than 0.0",
                 )

--- a/src/parameters/update_container_parameter_values.jl
+++ b/src/parameters/update_container_parameter_values.jl
@@ -390,9 +390,9 @@ function _update_parameter_values!(
                      Consider reviewing your models' horizon and interval definitions",
                 )
             end
-            if 0.0 > value || value > 1.0
+            if 0.0 > value 
                 error(
-                    "The value for the system state used in $(encode_key_as_string(get_attribute_key(attributes))): $(value) is out of the [0, 1] range",
+                    "The value for the system state used in $(encode_key_as_string(get_attribute_key(attributes))): $(value) is less than 0.0",
                 )
             end
             _set_param_value!(parameter_array, value, name, t)

--- a/src/simulation/simulation_events.jl
+++ b/src/simulation/simulation_events.jl
@@ -122,7 +122,7 @@ end
 
 function apply_affect!(
     simulation::Simulation,
-    ::EventModel{
+    event_model::EventModel{
         T,
         <:AbstractEventCondition,
     },
@@ -145,6 +145,7 @@ function apply_affect!(
             ParameterKey(AvailableStatusChangeCountdownParameter, dtype),
             device_names,
             event,
+            event_model,
             sim_time,
             rng,
         )
@@ -153,6 +154,7 @@ function apply_affect!(
             ParameterKey(AvailableStatusParameter, dtype),
             device_names,
             event,
+            event_model,
             sim_time,
             rng,
         )
@@ -161,6 +163,7 @@ function apply_affect!(
             VariableKey(ActivePowerVariable, dtype),
             device_names,
             event,
+            event_model,
             sim_time,
             rng,
         )
@@ -169,6 +172,7 @@ function apply_affect!(
             VariableKey(OnVariable, dtype),
             device_names,
             event,
+            event_model,
             sim_time,
             rng,
         )
@@ -179,6 +183,7 @@ function apply_affect!(
             ParameterKey(AvailableStatusChangeCountdownParameter, dtype),
             device_names,
             event,
+            event_model,
             sim_time,
             em_model_store,
         )
@@ -187,6 +192,7 @@ function apply_affect!(
             ParameterKey(AvailableStatusParameter, dtype),
             device_names,
             event,
+            event_model,
             sim_time,
             em_model_store,
         )
@@ -195,6 +201,7 @@ function apply_affect!(
             VariableKey(ActivePowerVariable, dtype),
             device_names,
             event,
+            event_model,
             sim_time,
             em_model_store,
         )
@@ -203,6 +210,7 @@ function apply_affect!(
             VariableKey(OnVariable, dtype),
             device_names,
             event,
+            event_model,
             sim_time,
             em_model_store,
         )

--- a/src/simulation/simulation_events.jl
+++ b/src/simulation/simulation_events.jl
@@ -47,7 +47,7 @@ function extend_event_parameters!(simulation::Simulation, event_model)
                 for name in device_names
                     if status_change_countdown_data.values[name, 1] > 1.0
                         starting_count = status_change_countdown_data.values[name, 1]
-                        for i in 1:length(status_change_countdown_data.values)
+                        for i in 1:length(status_change_countdown_data.values[name, :])
                             countdown_val = max(starting_count + 1 - i, 0.0)
                             if countdown_val == 0.0
                                 status_val = 1.0

--- a/src/simulation/simulation_events.jl
+++ b/src/simulation/simulation_events.jl
@@ -5,7 +5,6 @@ function apply_simulation_events!(simulation::Simulation)
     for event_model in events
         extend_event_parameters!(simulation, event_model)
         if check_condition(simulation_state, event_model)
-            @warn "Condition evaluated to true at time $(get_current_time(simulation))"
             # TODO: for other event categories we need to do something else
             em_model = get_emulation_model(get_models(simulation))
             sys = get_system(em_model)
@@ -13,7 +12,6 @@ function apply_simulation_events!(simulation::Simulation)
             for (event_uuid, device_type_maps) in
                 event_model.attribute_device_map[model_name]
                 event = PSY.get_supplemental_attribute(sys, event_uuid)
-                @warn "Applying affect for $device_type_maps"
                 apply_affect!(simulation, event_model, event, device_type_maps)
             end
         end

--- a/src/simulation/simulation_events.jl
+++ b/src/simulation/simulation_events.jl
@@ -93,11 +93,11 @@ function apply_affect!(
         end
         em_model = get_emulation_model(get_models(simulation))
         em_model_store = get_store_params(em_model)
-        # Order is required here. The AvailableStatusChangeParameter needs to be updated first
+        # Order is required here. The AvailableStatusChangeCountdownParameter needs to be updated first
         # to indicate that there is a change in the othe parameters
         update_system_state!(
             sim_state,
-            ParameterKey(AvailableStatusChangeParameter, dtype),
+            ParameterKey(AvailableStatusChangeCountdownParameter, dtype),
             device_names,
             event,
             sim_time,
@@ -127,11 +127,11 @@ function apply_affect!(
             sim_time,
             rng,
         )
-        # Order is required here too AvailableStatusChangeParameter needs to
+        # Order is required here too AvailableStatusChangeCountdownParameter needs to
         # go first to indicate that there is a change in the other values
         update_decision_state!(
             sim_state,
-            ParameterKey(AvailableStatusChangeParameter, dtype),
+            ParameterKey(AvailableStatusChangeCountdownParameter, dtype),
             device_names,
             event,
             sim_time,

--- a/src/simulation/simulation_state.jl
+++ b/src/simulation/simulation_state.jl
@@ -299,17 +299,7 @@ function update_decision_state!(
     @show state_timestamps
     @assert_op resolution_ratio >= 1
     # When we are back to the beggining of the simulation step.
-    if simulation_time > get_end_of_step_timestamp(state_data)
-        state_data_index = 1
-        state_data.timestamps[:] .=
-            range(
-                simulation_time;
-                step = state_resolution,
-                length = get_num_rows(state_data),
-            )
-    else
         state_data_index = find_timestamp_index(state_timestamps, simulation_time)
-    end
 
     for name in column_names
         state_data.values[name, state_data_index] = event_ocurrence_values[name, 1]
@@ -347,17 +337,7 @@ function update_decision_state!(
     state_timestamps = state_data.timestamps
     @assert_op resolution_ratio >= 1
 
-    if simulation_time > get_end_of_step_timestamp(state_data)
-        state_data_index = 1
-        state_data.timestamps[:] .=
-            range(
-                simulation_time;
-                step = state_resolution,
-                length = get_num_rows(state_data),
-            )
-    else
         state_data_index = find_timestamp_index(state_timestamps, simulation_time)
-    end
     @show current_time = get_current_time(state)
     @show state_data_index
     for name in column_names
@@ -398,17 +378,7 @@ function update_decision_state!(
     state_timestamps = state_data.timestamps
     @assert_op resolution_ratio >= 1
 
-    if simulation_time > get_end_of_step_timestamp(state_data)
-        state_data_index = 1
-        state_data.timestamps[:] .=
-            range(
-                simulation_time;
-                step = state_resolution,
-                length = get_num_rows(state_data),
-            )
-    else
         state_data_index = find_timestamp_index(state_timestamps, simulation_time)
-    end
     for name in column_names
         if event_ocurrence_data.values[name, state_data_index] == 1.0
             state_data.values[name, (state_data_index + 1):end] .= 0.0

--- a/src/simulation/simulation_state.jl
+++ b/src/simulation/simulation_state.jl
@@ -402,7 +402,7 @@ function update_decision_state!(
     resolution_ratio = model_resolution ÷ state_resolution
     @assert_op resolution_ratio >= 1
 
-if simulation_time > get_end_of_step_timestamp(state_data)
+    if simulation_time > get_end_of_step_timestamp(state_data)
         state_data_index = 1
         state_data.timestamps[:] .=
             range(
@@ -411,8 +411,8 @@ if simulation_time > get_end_of_step_timestamp(state_data)
                 length = get_num_rows(state_data),
             )
     else
-    state_data_index = find_timestamp_index(state_data.timestamps, simulation_time)
-end
+        state_data_index = find_timestamp_index(state_data.timestamps, simulation_time)
+    end
 
     offset = resolution_ratio - 1
     result_time_index = axes(store_data)[2]

--- a/src/simulation/simulation_state.jl
+++ b/src/simulation/simulation_state.jl
@@ -278,13 +278,14 @@ end
 
 function update_decision_state!(
     state::SimulationState,
-    key::ParameterKey{AvailableStatusChangeParameter, T},
+    key::ParameterKey{AvailableStatusChangeCountdownParameter, T},
     column_names::Set{String},
     event::PSY.Outage,
     simulation_time::Dates.DateTime,
     ::ModelStoreParams,
 ) where {T <: PSY.Component}
-    event_ocurrence_data = get_system_state_data(state, AvailableStatusChangeParameter(), T)
+    event_ocurrence_data =
+        get_system_state_data(state, AvailableStatusChangeCountdownParameter(), T)
     event_ocurrence_values = get_last_recorded_value(event_ocurrence_data)
     # This is required since the data for outages (mttr and λ) is always assumed to be on hourly resolution
 
@@ -337,7 +338,7 @@ function update_decision_state!(
     model_params::ModelStoreParams,
 ) where {T <: PSY.Component}
     event_ocurrence_data =
-        get_decision_state_data(state, AvailableStatusChangeParameter(), T)
+        get_decision_state_data(state, AvailableStatusChangeCountdownParameter(), T)
     state_data = get_decision_state_data(state, key)
     #column_names = get_column_names(key, state_data)[1]
     model_resolution = get_resolution(model_params)
@@ -387,7 +388,7 @@ function update_decision_state!(
 ) where {T <: VariableType, U <: PSY.Component}
     @error "UPDATE DECISION STATE $key"
     event_ocurrence_data =
-        get_decision_state_data(state, AvailableStatusChangeParameter(), U)
+        get_decision_state_data(state, AvailableStatusChangeCountdownParameter(), U)
     event_status_data = get_decision_state_data(state, AvailableStatusParameter(), U)
 
     state_data = get_decision_state_data(state, key)
@@ -561,7 +562,7 @@ function update_system_state!(
     available_status_parameter_values = get_last_recorded_value(available_status_parameter)
 
     available_status_change_parameter =
-        get_system_state_data(state, AvailableStatusChangeParameter(), T)
+        get_system_state_data(state, AvailableStatusChangeCountdownParameter(), T)
     available_status_change_parameter_values =
         get_last_recorded_value(available_status_change_parameter)
 
@@ -604,7 +605,7 @@ end
 
 function update_system_state!(
     state::SimulationState,
-    key::ParameterKey{AvailableStatusChangeParameter, T},
+    key::ParameterKey{AvailableStatusChangeCountdownParameter, T},
     column_names_::Set{String},
     event::PSY.Outage,
     simulation_time::Dates.DateTime,
@@ -626,7 +627,7 @@ function update_system_state!(
         current_status = available_status_parameter_values[name]
         if current_status == 1.0 && outage_ocurrence == 1.0
             available_status_change_parameter.values[name, 1] = outage_ocurrence
-            @error "Changed AvailableStatusChangeParameter for $name  to $outage_ocurrence in system state"
+            @error "Changed AvailableStatusChangeCountdownParameter for $name  to $outage_ocurrence in system state"
         else
             available_status_change_parameter.values[name, 1] = 0.0
         end
@@ -643,7 +644,8 @@ function update_system_state!(
     rng,
 ) where {T <: VariableType, U <: PSY.Component}
     sym_state = get_system_states(state)
-    event_ocurrence_data = get_system_state_data(state, AvailableStatusChangeParameter(), U)
+    event_ocurrence_data =
+        get_system_state_data(state, AvailableStatusChangeCountdownParameter(), U)
     event_ocurrence_values = get_last_recorded_value(event_ocurrence_data)
 
     system_dataset = get_dataset(sym_state, key)


### PR DESCRIPTION
This PR allows for outages that are not cleared within the span of the state horizon. This should work for both `GeometricDistributionForcedOutage` and `TimeSeriesForcedOutage`

@jd-lara In this implementation I preprocess the outage data so a one indicates a change in the status (see below). Where should this preprocessing occur in `PowerSimulations`? or can the API require data that represents changes and not the status? 

@llavin13 if you want to test this now with your system, use the function below to preprocess the data. This will likely change in the final implementation. 


```
function preprocess_outage_data(outage_data)
    status_change_data = zeros(length(outage_data))
    for ix in 1:length(outage_data)
        if ix > 1
            if outage_data[ix] != outage_data[ix - 1]
                status_change_data[ix - 1] = 1.0
            end
        end
    end
    return status_change_data
end
# This is ignored for now in this simulation setup
o_data = fill!(Vector{Float64}(undef, 8784), 0.0)
o_data[20:51] .= 1.0
outage_time_series1 = TimeArray(dates_ts, preprocess_outage_data(o_data))
```
