### PR TITLE
Fix docs build, add aux variable section

### DIFF
--- a/docs/src/api/PowerSimulations.md
+++ b/docs/src/api/PowerSimulations.md
@@ -160,13 +160,10 @@ RateofChangeConstraintSlackDown
 OnVariable
 StartVariable
 StopVariable
-TimeDurationOn
-TimeDurationOff
 HotStartVariable
 WarmStartVariable
 ColdStartVariable
 PowerAboveMinimumVariable
-PowerOutput
 ```
 
 ### Storage Unit Variables
@@ -212,6 +209,39 @@ InterfaceFlowSlackDown
 ```@docs
 UpperBoundFeedForwardSlack
 LowerBoundFeedForwardSlack
+```
+
+```@raw html
+&nbsp;
+&nbsp;
+```
+
+* * *
+
+## Auxiliary Variables
+
+### Thermal Unit Auxiliary Variables
+
+```@docs
+TimeDurationOn
+TimeDurationOff
+PowerOutput
+```
+
+### Bus Auxiliary Variables
+
+```@docs
+PowerFlowVoltageAngle
+PowerFlowVoltageMagnitude
+```
+
+### Branch Auxiliary Variables
+
+```@docs
+PowerFlowLineReactivePowerFromTo
+PowerFlowLineReactivePowerToFrom
+PowerFlowLineActivePowerFromTo
+PowerFlowLineActivePowerToFrom
 ```
 
 ```@raw html

--- a/src/simulation/simulation_results.jl
+++ b/src/simulation/simulation_results.jl
@@ -205,8 +205,8 @@ Return SimulationProblemResults corresponding to a SimulationResults
 # Arguments
  - `sim_results::PSI.SimulationResults`: the simulation results to read from
  - `problem::String`: the name of the problem (e.g., "UC", "ED")
- - `populate_system::Bool = true`: whether to set the results' system using
- [`read_serialized_system`](@ref)
+ - `populate_system::Bool = true`: whether to set the results' system as if using
+   [`get_system!`](@ref)
  - `populate_units::Union{IS.UnitSystem, String, Nothing} = IS.UnitSystem.NATURAL_UNITS`:
    the units system with which to populate the results' system, if any (requires
    `populate_system=true`)


### PR DESCRIPTION
https://github.com/NREL-Sienna/PowerSimulations.jl/pull/1240 surfaced an issue in the `get_decision_problem_results` docstring that this fixes. The other reason the docs build was failing is that the new power flow-related auxiliary variables were not included; here I add a new section and put all the auxiliary variables there.