### PR TITLE
Update to `Vector{DateTime}` in Results

### DIFF
--- a/src/simulation/decision_model_simulation_results.jl
+++ b/src/simulation/decision_model_simulation_results.jl
@@ -447,7 +447,7 @@ function get_realized_timestamps(
     resolution = get_resolution(res)
     intervals = diff(timestamps)
     if isempty(intervals) && isnothing(resolution)
-        # If Single Interval Step and Single Resolution: use dummy resolution/interval
+        # If Single Interval Step and single time step: use dummy resolution/interval
         interval = Dates.Millisecond(1)
         resolution = Dates.Millisecond(1)
     elseif !isempty(intervals) && isnothing(resolution)

--- a/src/simulation/decision_model_simulation_results.jl
+++ b/src/simulation/decision_model_simulation_results.jl
@@ -447,18 +447,18 @@ function get_realized_timestamps(
     resolution = get_resolution(res)
     intervals = diff(timestamps)
     if isempty(intervals) && isnothing(resolution)
-        # If Single Interval Step and Single Resolution use dummy resolution
+        # If Single Interval Step and Single Resolution: use dummy resolution/interval
         interval = Dates.Millisecond(1)
         resolution = Dates.Millisecond(1)
     elseif !isempty(intervals) && isnothing(resolution)
-        # Multiple simulation steps but single resolution
+        # Multiple simulation steps but single time step: Set resolution = interval
         interval = first(intervals)
         resolution = interval
     elseif isempty(intervals) && !isnothing(resolution)
-        # There is multiple time steps but single simulation
+        # There is multiple time steps but single simulation step: Set interval = resolution
         interval = resolution
     else
-        # Both data are available
+        # Both data are available: Use existing resolution and grab first interval
         interval = first(intervals)
     end
     horizon = get_forecast_horizon(res)

--- a/src/simulation/decision_model_simulation_results.jl
+++ b/src/simulation/decision_model_simulation_results.jl
@@ -444,8 +444,23 @@ function get_realized_timestamps(
     len::Union{Int, Nothing} = nothing,
 )
     timestamps = get_timestamps(res)
-    interval = timestamps.step
     resolution = get_resolution(res)
+    intervals = diff(timestamps)
+    if isempty(intervals) && isnothing(resolution)
+        # If Single Interval Step and Single Resolution use dummy resolution
+        interval = Dates.Millisecond(1)
+        resolution = Dates.Millisecond(1)
+    elseif !isempty(intervals) && isnothing(resolution)
+        # Multiple simulation steps but single resolution
+        interval = first(intervals)
+        resolution = interval
+    elseif isempty(intervals) && !isnothing(resolution)
+        # There is multiple time steps but single simulation
+        interval = resolution
+    else
+        # Both data are available
+        interval = first(intervals)
+    end
     horizon = get_forecast_horizon(res)
     start_time = isnothing(start_time) ? first(timestamps) : start_time
     end_time =

--- a/src/utils/printing.jl
+++ b/src/utils/printing.jl
@@ -456,9 +456,9 @@ function _show_method(io::IO, results::SimulationResults, backend::Symbol; kwarg
     table = Matrix{Any}(undef, length(results.decision_problem_results), length(header))
     for (ix, (key, result)) in enumerate(results.decision_problem_results)
         table[ix, 1] = key
-        table[ix, 2] = result.timestamps.start
-        table[ix, 3] = Dates.Minute(result.timestamps.step)
-        table[ix, 4] = result.timestamps.stop
+        table[ix, 2] = first(result.timestamps)
+        table[ix, 3] = Dates.Minute(first(diff(result.timestamps)))
+        table[ix, 4] = last(result.timestamps)
     end
     println(io)
     PrettyTables.pretty_table(
@@ -505,13 +505,16 @@ function _show_method(
     timestamps = get_timestamps(results)
 
     if backend == :html
-        println(io, "<p> Start: $(timestamps.start)</p>")
-        println(io, "<p> End: $(timestamps.stop)</p>")
-        println(io, "<p> Resolution: $(Dates.Minute(timestamps.step))</p>")
+        println(io, "<p> Start: $(first(timestamps))</p>")
+        println(io, "<p> End: $(last(timestamps))</p>")
+        println(
+            io,
+            "<p> Resolution: $(Dates.Minute(IS.Optimization.get_resolution(results)))</p>",
+        )
     else
-        println(io, "Start: $(timestamps.start)")
-        println(io, "End: $(timestamps.stop)")
-        println(io, "Resolution: $(Dates.Minute(timestamps.step))")
+        println(io, "Start: $(first(timestamps))")
+        println(io, "End: $(last(timestamps))")
+        println(io, "Resolution: $(Dates.Minute(IS.Optimization.get_resolution(results)))")
     end
 
     values = Dict{String, Vector{String}}(


### PR DESCRIPTION
Companion PR with: https://github.com/NREL-Sienna/InfrastructureSystems.jl/pull/438

The main change is related when having to do read_realized_terms in a Simulation and generating the ranges in DecisionProblems without having available the methods for step. 

The main problem happens now when you received a single simulation step or a single time step, and having to create a step in that case. 

The approach here is covering all the previous cases to properly have the necessary intervals and resolutions in those cases. It took some time to debug this. Tests are passing locally with the proper IS branch:
![image](https://github.com/user-attachments/assets/7781783b-3c88-4873-80b0-be46e7d5d519)


Also updated the printing as we don't have step now.