### PR TITLE
hvdc area fix

### DIFF
--- a/src/core/optimization_container.jl
+++ b/src/core/optimization_container.jl
@@ -592,7 +592,10 @@ function _verify_area_subnetwork_topology(sys::PSY.System, subnetworks::Dict{Int
     area_map = PSY.get_aggregation_topology_mapping(PSY.Area, sys)
     for (area, buses) in area_map
         bus_numbers =
-            [PSY.get_number(b) for b in buses if PSY.get_bustype(b) != PSY.ACBusTypes.ISOLATED]
+            [
+                PSY.get_number(b) for
+                b in buses if PSY.get_bustype(b) != PSY.ACBusTypes.ISOLATED
+            ]
         subnets = Int[]
         for (subnet, subnet_bus_numbers) in subnetworks
             if !isdisjoint(bus_numbers, subnet_bus_numbers)

--- a/src/core/optimization_container.jl
+++ b/src/core/optimization_container.jl
@@ -592,7 +592,7 @@ function _verify_area_subnetwork_topology(sys::PSY.System, subnetworks::Dict{Int
     area_map = PSY.get_aggregation_topology_mapping(PSY.Area, sys)
     for (area, buses) in area_map
         bus_numbers =
-            [PSY.get_number(b) for b in buses if PSY.get_bustype(b) != ACBusTypes.ISOLATED]
+            [PSY.get_number(b) for b in buses if PSY.get_bustype(b) != PSY.ACBusTypes.ISOLATED]
         subnets = Int[]
         for (subnet, subnet_bus_numbers) in subnetworks
             if !isdisjoint(bus_numbers, subnet_bus_numbers)

--- a/src/core/optimization_container.jl
+++ b/src/core/optimization_container.jl
@@ -516,13 +516,6 @@ function _make_system_expressions!(
     ::Type{AreaBalancePowerModel},
     areas::IS.FlattenIteratorWrapper{PSY.Area},
 )
-    if length(subnetworks) > 1
-        throw(
-            IS.ConflictingInputsError(
-                "AreaBalancePowerModel doesn't support systems with multiple asynchronous areas",
-            ),
-        )
-    end
     time_steps = get_time_steps(container)
     container.expressions = Dict(
         ExpressionKey(ActivePowerBalance, PSY.Area) =>
@@ -588,6 +581,35 @@ function initialize_system_expressions!(
     return
 end
 
+function _verify_area_subnetwork_topology(sys::PSY.System, subnetworks::Dict{Int, Set{Int}})
+    if length(subnetworks) < 1
+        @debug "Only one subnetwork detected in the system. Area - Subnetwork topology check is valid."
+        return
+    end
+
+    @warn "More than one subnetwork detected in AreaBalancePowerModel. Topology consistency checks must be conducted."
+
+    area_map = PSY.get_aggregation_topology_mapping(PSY.Area, sys)
+    for (area, buses) in area_map
+        bus_numbers =
+            [PSY.get_number(b) for b in buses if PSY.get_bustype(b) != ACBusTypes.ISOLATED]
+        subnets = Int[]
+        for (subnet, subnet_bus_numbers) in subnetworks
+            if !isdisjoint(bus_numbers, subnet_bus_numbers)
+                push!(subnets, subnet)
+            end
+        end
+        if length(subnets) > 1
+            @error "Area $(PSY.get_name(area)) is connected to multiple subnetworks $(subnets)."
+            throw(
+                IS.ConflictingInputsError(
+                    "AreaBalancePowerModel doesn't support systems with Areas distributed across multiple asynchronous areas",
+                ))
+        end
+    end
+    return
+end
+
 function initialize_system_expressions!(
     container::OptimizationContainer,
     network_model::NetworkModel{AreaBalancePowerModel},
@@ -603,7 +625,16 @@ function initialize_system_expressions!(
             ),
         )
     end
-    @assert !isempty(areas)
+    area_interchanges = PSY.get_available_components(PSY.AreaInterchange, system)
+    if isempty(area_interchanges) ||
+       PSY.AreaInterchange ∉ network_model.modeled_branch_types
+        @warn "The system does not contain any AreaInterchanges. The model won't have any power flowing between the areas."
+    end
+    if !isempty(area_interchanges) &&
+       PSY.AreaInterchange ∉ network_model.modeled_branch_types
+        @warn "AreaInterchanges are not included in the model template. The model won't have any power flowing between the areas."
+    end
+    _verify_area_subnetwork_topology(system, subnetworks)
     _make_system_expressions!(container, subnetworks, AreaBalancePowerModel, areas)
     return
 end

--- a/src/devices_models/device_constructors/branch_constructor.jl
+++ b/src/devices_models/device_constructors/branch_constructor.jl
@@ -590,7 +590,7 @@ function construct_device!(
     ::ArgumentConstructStage,
     device_model::DeviceModel{T, HVDCTwoTerminalDispatch},
     ::NetworkModel{AreaBalancePowerModel},
-) where {T <: TwoTerminalHVDCTypes, U <: AbstractTwoTerminalDCLineFormulation}
+) where {T <: TwoTerminalHVDCTypes}
     @warn "AreaBalancePowerModel doesn't model individual line flows for $T. Arguments not built"
     return
 end
@@ -601,7 +601,7 @@ function construct_device!(
     ::ModelConstructStage,
     device_model::DeviceModel{T, HVDCTwoTerminalDispatch},
     ::NetworkModel{AreaBalancePowerModel},
-) where {T <: TwoTerminalHVDCTypes, U <: AbstractTwoTerminalDCLineFormulation}
+) where {T <: TwoTerminalHVDCTypes}
     @warn "AreaBalancePowerModel doesn't model individual line flows for $T. Model not built"
     return
 end

--- a/src/devices_models/device_constructors/branch_constructor.jl
+++ b/src/devices_models/device_constructors/branch_constructor.jl
@@ -580,7 +580,7 @@ function construct_device!(
 )
     devices = get_available_components(device_model, sys)
     add_constraint_dual!(container, sys, device_model)
-    add_feedforward_constraints!(container, model, devices)
+    add_feedforward_constraints!(container, device_model, devices)
     return
 end
 

--- a/src/devices_models/device_constructors/branch_constructor.jl
+++ b/src/devices_models/device_constructors/branch_constructor.jl
@@ -584,6 +584,74 @@ function construct_device!(
     return
 end
 
+function construct_device!(
+    container::OptimizationContainer,
+    sys::PSY.System,
+    ::ArgumentConstructStage,
+    device_model::DeviceModel{T, HVDCTwoTerminalDispatch},
+    ::NetworkModel{AreaBalancePowerModel},
+) where {T <: TwoTerminalHVDCTypes, U <: AbstractTwoTerminalDCLineFormulation}
+    @warn "AreaBalancePowerModel doesn't model individual line flows for $T. Arguments not built"
+    return
+end
+
+function construct_device!(
+    container::OptimizationContainer,
+    sys::PSY.System,
+    ::ModelConstructStage,
+    device_model::DeviceModel{T, HVDCTwoTerminalDispatch},
+    ::NetworkModel{AreaBalancePowerModel},
+) where {T <: TwoTerminalHVDCTypes, U <: AbstractTwoTerminalDCLineFormulation}
+    @warn "AreaBalancePowerModel doesn't model individual line flows for $T. Model not built"
+    return
+end
+
+# Repeated method to avoid ambiguity between HVDCTwoTerminalUnbounded, HVDCTwoTerminalLossless and HVDCTwoTerminalDispatch
+function construct_device!(
+    container::OptimizationContainer,
+    sys::PSY.System,
+    ::ArgumentConstructStage,
+    device_model::DeviceModel{T, HVDCTwoTerminalUnbounded},
+    ::NetworkModel{AreaBalancePowerModel},
+) where {T <: TwoTerminalHVDCTypes}
+    @warn "AreaBalancePowerModel doesn't model individual line flows for $T. Arguments not built"
+    return
+end
+
+function construct_device!(
+    container::OptimizationContainer,
+    sys::PSY.System,
+    ::ModelConstructStage,
+    device_model::DeviceModel{T, HVDCTwoTerminalUnbounded},
+    ::NetworkModel{AreaBalancePowerModel},
+) where {T <: TwoTerminalHVDCTypes}
+    @warn "AreaBalancePowerModel doesn't model individual line flows for $T. Model not built"
+    return
+end
+
+# Repeated method to avoid ambiguity between HVDCTwoTerminalUnbounded, HVDCTwoTerminalLossless and HVDCTwoTerminalDispatch
+function construct_device!(
+    container::OptimizationContainer,
+    sys::PSY.System,
+    ::ArgumentConstructStage,
+    device_model::DeviceModel{T, HVDCTwoTerminalLossless},
+    ::NetworkModel{AreaBalancePowerModel},
+) where {T <: TwoTerminalHVDCTypes}
+    @warn "AreaBalancePowerModel doesn't model individual line flows for $T. Arguments not built"
+    return
+end
+
+function construct_device!(
+    container::OptimizationContainer,
+    sys::PSY.System,
+    ::ModelConstructStage,
+    device_model::DeviceModel{T, HVDCTwoTerminalLossless},
+    ::NetworkModel{AreaBalancePowerModel},
+) where {T <: TwoTerminalHVDCTypes}
+    @warn "AreaBalancePowerModel doesn't model individual line flows for $T. Model not built"
+    return
+end
+
 # Repeated method to avoid ambiguity between HVDCTwoTerminalUnbounded and HVDCTwoTerminalLossless
 function construct_device!(
     container::OptimizationContainer,

--- a/src/devices_models/devices/common/add_to_expression.jl
+++ b/src/devices_models/devices/common/add_to_expression.jl
@@ -635,6 +635,36 @@ function add_to_expression!(
     container::OptimizationContainer,
     ::Type{T},
     ::Type{U},
+    devices::IS.FlattenIteratorWrapper{PSY.TwoTerminalHVDCLine},
+    ::DeviceModel{PSY.TwoTerminalHVDCLine, HVDCTwoTerminalDispatch},
+    network_model::NetworkModel{AreaBalancePowerModel},
+) where {
+    T <: ActivePowerBalance,
+    U <: FlowActivePowerToFromVariable,
+}
+    error("here")
+    variable = get_variable(container, U(), V)
+    expression = get_expression(container, T(), PSY.ACBus)
+    radial_network_reduction = get_radial_network_reduction(network_model)
+    for d in devices
+        name = PSY.get_name(d)
+        bus_no_ = PSY.get_number(PSY.get_arc(d).to)
+        bus_no = PNM.get_mapped_bus_number(radial_network_reduction, bus_no_)
+        for t in get_time_steps(container)
+            _add_to_jump_expression!(
+                expression[bus_no, t],
+                variable[name, t],
+                get_variable_multiplier(U(), V, W()),
+            )
+        end
+    end
+    return
+end
+
+function add_to_expression!(
+    container::OptimizationContainer,
+    ::Type{T},
+    ::Type{U},
     devices::IS.FlattenIteratorWrapper{V},
     ::DeviceModel{V, W},
     network_model::NetworkModel{X},

--- a/src/devices_models/devices/common/objective_function/market_bid.jl
+++ b/src/devices_models/devices/common/objective_function/market_bid.jl
@@ -141,7 +141,8 @@ function _get_pwl_cost_expression(
     for (i, cost) in enumerate(y_coords_cost_data)
         JuMP.add_to_expression!(
             gen_cost,
-            cost * multiplier * pwl_var_container[(name, i, time_period)],
+            (cost * multiplier),
+            pwl_var_container[(name, i, time_period)],
         )
     end
     return gen_cost
@@ -196,7 +197,8 @@ function _get_pwl_cost_expression(
     for i in 1:length(slopes)
         JuMP.add_to_expression!(
             ordc_cost,
-            slopes[i] * multiplier * pwl_var_container[(name, i, time_period)],
+            slopes[i] * multiplier,
+            pwl_var_container[(name, i, time_period)],
         )
     end
     return ordc_cost
@@ -241,7 +243,8 @@ function _get_pwl_cost_expression(
     for (i, cost) in enumerate(cost_data)
         JuMP.add_to_expression!(
             gen_cost,
-            cost * multiplier * pwl_var_container[(name, i, time_period)],
+            cost * multiplier,
+            pwl_var_container[(name, i, time_period)],
         )
     end
     return gen_cost

--- a/src/devices_models/devices/common/objective_function/piecewise_linear.jl
+++ b/src/devices_models/devices/common/objective_function/piecewise_linear.jl
@@ -264,7 +264,8 @@ function _get_pwl_cost_expression(
     for (i, cost) in enumerate(y_coords_cost_data)
         JuMP.add_to_expression!(
             gen_cost,
-            cost * multiplier * pwl_var_container[(name, i, time_period)],
+            (cost * multiplier),
+            pwl_var_container[(name, i, time_period)],
         )
     end
     return gen_cost

--- a/src/services_models/agc.jl
+++ b/src/services_models/agc.jl
@@ -157,9 +157,9 @@ function add_constraints!(
             a = PSY.get_name(agc)
             area_name = PSY.get_name(PSY.get_area(agc))
             JuMP.add_to_expression!(system_balance, R_up[a, t])
-            JuMP.add_to_expression!(system_balance, -1 * R_dn[a, t])
+            JuMP.add_to_expression!(system_balance, -1.0, R_dn[a, t])
             JuMP.add_to_expression!(system_balance, R_up_emergency[area_name, t])
-            JuMP.add_to_expression!(system_balance, -1 * R_dn_emergency[area_name, t])
+            JuMP.add_to_expression!(system_balance, -1.0, R_dn_emergency[area_name, t])
         end
         const_container[t] = JuMP.@constraint(
             container.JuMPmodel,

--- a/src/services_models/reserve_group.jl
+++ b/src/services_models/reserve_group.jl
@@ -60,7 +60,7 @@ function add_constraints!(
     for t in time_steps
         resource_expression = JuMP.GenericAffExpr{Float64, JuMP.VariableRef}()
         for reserve_variable in reserve_variables
-            JuMP.add_to_expression!(resource_expression, sum(reserve_variable[:, t]))
+            JuMP.add_to_expression!(resource_expression, sum(@view reserve_variable[:, t]))
         end
         if use_slacks
             resource_expression += slack_vars[t]

--- a/src/services_models/services_constructor.jl
+++ b/src/services_models/services_constructor.jl
@@ -553,6 +553,41 @@ function construct_service!(
     return
 end
 
+# Repeated Methods to avoid ambiguity between ConstantMaxInterfaceFlow and VariableMaxInterfaceFlow
+function construct_service!(
+    container::OptimizationContainer,
+    sys::PSY.System,
+    ::ModelConstructStage,
+    model::ServiceModel{T, ConstantMaxInterfaceFlow},
+    devices_template::Dict{Symbol, DeviceModel},
+    incompatible_device_types::Set{<:DataType},
+    network_model::NetworkModel{AreaBalancePowerModel},
+) where {T <: PSY.TransmissionInterface}
+    throw(
+        IS.ConflictingInputsError(
+            "AreaBalancePowerModel doesn't model individual line flows and it is not compatible with the addition of TransmissionInterface models",
+        ),
+    )
+    return
+end
+
+function construct_service!(
+    container::OptimizationContainer,
+    sys::PSY.System,
+    ::ModelConstructStage,
+    model::ServiceModel{T, VariableMaxInterfaceFlow},
+    devices_template::Dict{Symbol, DeviceModel},
+    incompatible_device_types::Set{<:DataType},
+    network_model::NetworkModel{AreaBalancePowerModel},
+) where {T <: PSY.TransmissionInterface}
+    throw(
+        IS.ConflictingInputsError(
+            "AreaBalancePowerModel doesn't model individual line flows and it is not compatible with the addition of TransmissionInterface models",
+        ),
+    )
+    return
+end
+
 function construct_service!(
     container::OptimizationContainer,
     sys::PSY.System,

--- a/src/simulation/simulation.jl
+++ b/src/simulation/simulation.jl
@@ -178,7 +178,7 @@ function _get_simulation_initial_times!(sim::Simulation)
         if model_horizon > system_horizon
             throw(
                 IS.ConflictingInputsError(
-                    "$(get_name(model)) model horizon ($model_horizon) and forecast horizon ($system_horizon) are not compatible",
+                    "$(get_name(model)) model horizon: $(Dates.canonicalize(model_horizon)) and forecast horizon: $(Dates.canonicalize(system_horizon)) are not compatible",
                 ),
             )
         end


### PR DESCRIPTION
Still needs testing but this should address the issue with the area/synch regions mismatch @llavin13 reported in #1269. 

One situation to note here is that we need to throw meaningful errors when users add TransmissionInterfaces to AreaBalance models because it doesn't make sense since there aren't any line flows calculated. 