### PR TITLE
Fix #1298, fix #1297 for thermals, test that

### DIFF
--- a/src/devices_models/devices/common/objective_function/common.jl
+++ b/src/devices_models/devices/common/objective_function/common.jl
@@ -116,17 +116,12 @@ function add_proportional_cost!(
         for t in get_time_steps(container)
             cost_term = proportional_cost(container, op_cost_data, U(), d, V(), t)
             iszero(cost_term) && continue
-            if !PSY.get_must_run(d)
-                exp = _add_proportional_term!(container, U(), d, cost_term * multiplier, t)
-                add_to_expression!(container, ProductionCostExpression, exp, d, t)
+            exp = if PSY.get_must_run(d)
+                cost_term * multiplier  # note we do not add this to the objective function
+            else
+                _add_proportional_term!(container, U(), d, cost_term * multiplier, t)
             end
-            add_to_expression!(
-                container,
-                ProductionCostExpression,
-                cost_term * multiplier,
-                d,
-                t,
-            )
+            add_to_expression!(container, ProductionCostExpression, exp, d, t)
         end
     end
     return

--- a/src/devices_models/devices/thermal_generation.jl
+++ b/src/devices_models/devices/thermal_generation.jl
@@ -91,10 +91,12 @@ function proportional_cost(container::OptimizationContainer, cost::PSY.ThermalGe
 end
 
 function proportional_cost(container::OptimizationContainer, cost::PSY.MarketBidCost, S::OnVariable, T::PSY.ThermalGen, U::AbstractThermalFormulation, t::Int)
+    # TODO handle time series case
     return proportional_cost(cost, S, T, U)
 end
 
-proportional_cost(cost::PSY.MarketBidCost, ::OnVariable, ::PSY.ThermalGen, ::AbstractThermalFormulation) = PSY.get_no_load_cost(cost)
+proportional_cost(cost::PSY.MarketBidCost, ::OnVariable, ::PSY.ThermalGen, ::AbstractThermalFormulation) =
+    PSY.get_initial_input(PSY.get_incremental_offer_curves(cost))
 
 proportional_cost(::Union{PSY.MarketBidCost, PSY.ThermalGenerationCost}, ::Union{RateofChangeConstraintSlackUp, RateofChangeConstraintSlackDown}, ::PSY.ThermalGen, ::AbstractThermalFormulation) = CONSTRAINT_VIOLATION_SLACK_COST
 


### PR DESCRIPTION
Fixes #1298
Fixes #1297

Does not handle the time varying case or non-thermal devices (e.g., does not fix #1299). Adds tests sufficient to fail in the absence of these fixes, but I still think we could use more rigorous testing of this kind of thing in general.