### PR TITLE
change names for pnm compatibility

### DIFF
--- a/src/core/network_model.jl
+++ b/src/core/network_model.jl
@@ -36,7 +36,7 @@ mutable struct NetworkModel{T <: PM.AbstractPowerModel}
     subnetworks::Dict{Int, Set{Int}}
     bus_area_map::Dict{PSY.ACBus, Int}
     duals::Vector{DataType}
-    radial_network_reduction::PNM.NetworkReduction
+    network_reduction::PNM.NetworkReduction
     reduce_radial_branches::Bool
     power_flow_evaluation::Vector{PFS.PowerFlowEvaluationModel}
     subsystem::Union{Nothing, String}
@@ -73,7 +73,7 @@ end
 get_use_slacks(m::NetworkModel) = m.use_slacks
 get_PTDF_matrix(m::NetworkModel) = m.PTDF_matrix
 get_reduce_radial_branches(m::NetworkModel) = m.reduce_radial_branches
-get_radial_network_reduction(m::NetworkModel) = m.radial_network_reduction
+get_network_reduction(m::NetworkModel) = m.network_reduction
 get_duals(m::NetworkModel) = m.duals
 get_network_formulation(::NetworkModel{T}) where {T} = T
 get_reference_buses(m::NetworkModel{T}) where {T <: PM.AbstractPowerModel} =
@@ -93,11 +93,11 @@ function add_dual!(model::NetworkModel, dual)
     return
 end
 
-function check_radial_branch_reduction_compatibility(
+function check_network_reduction_compatibility(
     ::Type{T},
 ) where {T <: PM.AbstractPowerModel}
-    if T ∈ INCOMPATIBLE_WITH_RADIAL_BRANCHES_POWERMODELS
-        error("Network Model $T is not compatible with radial branch reduction")
+    if T ∈ INCOMPATIBLE_WITH_NETWORK_REDUCTION_POWERMODELS
+        error("Network Model $T is not compatible with network reduction")
     end
     return
 end
@@ -109,9 +109,8 @@ function instantiate_network_model(
     if isempty(model.subnetworks)
         model.subnetworks = PNM.find_subnetworks(sys)
     end
-    if model.reduce_radial_branches
-        check_radial_branch_reduction_compatibility(T)
-        model.radial_network_reduction = PNM.NetworkReduction(sys)
+    if !isempty(model.network_reduction)
+        check_network_reduction_compatibility(T)
     end
     return
 end
@@ -137,23 +136,40 @@ function instantiate_network_model(
 )
     if get_PTDF_matrix(model) === nothing
         @info "PTDF Matrix not provided. Calculating using PowerNetworkMatrices.PTDF"
+        if model.reduce_radial_branches
+            network_reduction = PNM.get_radial_reduction(sys)
+        else
+            network_reduction = PNM.NetworkReduction()
+        end
         model.PTDF_matrix =
-            PNM.PTDF(sys; reduce_radial_branches = model.reduce_radial_branches)
+            PNM.VirtualPTDF(sys; network_reduction = network_reduction)
     end
 
-    if !model.reduce_radial_branches && !isempty(model.PTDF_matrix.radial_network_reduction)
+    if !model.reduce_radial_branches &&
+       model.PTDF_matrix.network_reduction.reduction_type ==
+       PNM.NetworkReductionTypes.RADIAL
         throw(
             IS.ConflictingInputsError(
                 "The provided PTDF Matrix has reduced radial branches and mismatches the network \\
-                model specification radial_network_reduction = false. Set the keyword argument \\
-                radial_network_reduction = true in your network model"),
+                model specification reduce_radial_branches = false. Set the keyword argument \\
+                reduce_radial_branches = true in your network model"),
+        )
+    end
+
+    if model.reduce_radial_branches &&
+       model.PTDF_matrix.network_reduction.reduction_type == PNM.NetworkReductionTypes.WARD
+        throw(
+            IS.ConflictingInputsError(
+                "The provided PTDF Matrix has  a ward reduction specified and the keyword argument \\
+                reduce_radial_branches = true. Set the keyword argument reduce_radial_branches = false \\
+                or provide a modified PTDF Matrix without the Ward reduction."),
         )
     end
 
     if model.reduce_radial_branches
-        @assert !isempty(model.PTDF_matrix.radial_network_reduction)
-        model.radial_network_reduction = model.PTDF_matrix.radial_network_reduction
+        @assert !isempty(model.PTDF_matrix.network_reduction)
     end
+    model.network_reduction = model.PTDF_matrix.network_reduction
 
     get_PTDF_matrix(model).subnetworks
     model.subnetworks = deepcopy(get_PTDF_matrix(model).subnetworks)
@@ -170,10 +186,10 @@ function _assign_subnetworks_to_buses(
 ) where {T <: Union{CopperPlatePowerModel, AbstractPTDFModel}}
     subnetworks = model.subnetworks
     temp_bus_map = Dict{Int, Int}()
-    radial_network_reduction = PSI.get_radial_network_reduction(model)
+    network_reduction = PSI.get_network_reduction(model)
     for bus in PSI.get_available_components(model, PSY.ACBus, sys)
         bus_no = PSY.get_number(bus)
-        mapped_bus_no = PNM.get_mapped_bus_number(radial_network_reduction, bus)
+        mapped_bus_no = PNM.get_mapped_bus_number(network_reduction, bus)
         if haskey(temp_bus_map, bus_no)
             model.bus_area_map[bus] = temp_bus_map[bus_no]
             continue
@@ -194,12 +210,10 @@ function _assign_subnetworks_to_buses(
     end
     return
 end
-
 _assign_subnetworks_to_buses(
     ::NetworkModel{T},
     ::PSY.System,
 ) where {T <: PM.AbstractPowerModel} = nothing
-
 function get_reference_bus(
     model::NetworkModel{T},
     b::PSY.ACBus,

--- a/src/core/optimization_container.jl
+++ b/src/core/optimization_container.jl
@@ -650,7 +650,7 @@ function build_impl!(
         get_network_model(template),
         transmission_model.subnetworks,
         sys,
-        transmission_model.radial_network_reduction.bus_reduction_map)
+        transmission_model.network_reduction.bus_reduction_map)
 
     # Order is required
     for device_model in values(template.devices)

--- a/src/devices_models/devices/AC_branches.jl
+++ b/src/devices_models/devices/AC_branches.jl
@@ -138,12 +138,12 @@ function branch_rate_bounds!(
 ) where {B <: PSY.ACBranch}
     var = get_variable(container, FlowActivePowerVariable(), B)
 
-    radial_network_reduction = get_radial_network_reduction(network_model)
-    radial_branches_names = PNM.get_radial_branches(radial_network_reduction)
+    network_reduction = get_network_reduction(network_model)
+    removed_branches_names = PNM.get_removed_branches(network_reduction)
 
     for d in devices
         name = PSY.get_name(d)
-        if name ∈ radial_branches_names
+        if name ∈ removed_branches_names
             continue
         end
         for t in get_time_steps(container)
@@ -166,12 +166,12 @@ function branch_rate_bounds!(
     ]
 
     time_steps = get_time_steps(container)
-    radial_network_reduction = get_radial_network_reduction(network_model)
-    radial_branches_names = PNM.get_radial_branches(radial_network_reduction)
+    network_reduction = get_network_reduction(network_model)
+    removed_branches_names = PNM.get_removed_branches(network_reduction)
 
     for d in devices
         name = PSY.get_name(d)
-        if name ∈ radial_branches_names
+        if name ∈ removed_branches_names
             continue
         end
         for t in time_steps, var in vars
@@ -357,11 +357,11 @@ function add_constraints!(
     V <: PM.AbstractActivePowerModel,
 }
     time_steps = get_time_steps(container)
-    radial_network_reduction = get_radial_network_reduction(network_model)
-    if isempty(radial_network_reduction)
+    network_reduction = get_network_reduction(network_model)
+    if isempty(network_reduction)
         device_names = [PSY.get_name(d) for d in devices]
     else
-        device_names = PNM.get_meshed_branches(radial_network_reduction)
+        device_names = PNM.get_retained_branches(network_reduction)  #TODO need added branches here for ward?
     end
 
     con_lb =
@@ -393,7 +393,7 @@ function add_constraints!(
 
     for device in devices
         ci_name = PSY.get_name(device)
-        if ci_name ∈ PNM.get_radial_branches(radial_network_reduction)
+        if ci_name ∈ PNM.get_removed_branches(network_reduction)
             continue
         end
         limits = get_min_max_limits(device, RateLimitConstraint, U) # depends on constraint type and formulation type
@@ -444,12 +444,12 @@ function _constraint_without_slacks!(
     constraint::JuMPConstraintArray,
     rating_data::Vector{Tuple{String, Float64}},
     time_steps::UnitRange{Int64},
-    radial_branches_names::Set{String},
+    removed_branches_names::Set{String},
     var1::JuMPVariableArray,
     var2::JuMPVariableArray,
 )
     for (branch_name, branch_rate) in rating_data
-        if branch_name ∈ radial_branches_names
+        if branch_name ∈ removed_branches_names
             continue
         end
         for t in time_steps
@@ -467,13 +467,13 @@ function _constraint_with_slacks!(
     constraint::JuMPConstraintArray,
     rating_data::Vector{Tuple{String, Float64}},
     time_steps::UnitRange{Int64},
-    radial_branches_names::Set{String},
+    removed_branches_names::Set{String},
     var1::JuMPVariableArray,
     var2::JuMPVariableArray,
     slack_ub::JuMPVariableArray,
 )
     for (branch_name, branch_rate) in rating_data
-        if branch_name ∈ radial_branches_names
+        if branch_name ∈ removed_branches_names
             continue
         end
         for t in time_steps
@@ -511,8 +511,8 @@ function add_constraints!(
     )
     constraint = get_constraint(container, cons_type(), B)
 
-    radial_network_reduction = get_radial_network_reduction(network_model)
-    radial_branches_names = PNM.get_radial_branches(radial_network_reduction)
+    network_reduction = get_network_reduction(network_model)
+    removed_branches_names = PNM.get_removed_branches(network_reduction)
 
     use_slacks = get_use_slacks(device_model)
     if use_slacks
@@ -522,7 +522,7 @@ function add_constraints!(
             constraint,
             rating_data,
             time_steps,
-            radial_branches_names,
+            removed_branches_names,
             var1,
             var2,
             slack_ub,
@@ -534,7 +534,7 @@ function add_constraints!(
         constraint,
         rating_data,
         time_steps,
-        radial_branches_names,
+        removed_branches_names,
         var1,
         var2,
     )
@@ -566,11 +566,11 @@ function add_constraints!(
     )
     constraint = get_constraint(container, cons_type(), B)
 
-    radial_network_reduction = get_radial_network_reduction(network_model)
-    radial_branches_names = PNM.get_radial_branches(radial_network_reduction)
+    network_reduction = get_network_reduction(network_model)
+    removed_branches_names = PNM.get_removed_branches(network_reduction)
 
     for r in rating_data
-        if r[1] ∈ radial_branches_names
+        if r[1] ∈ removed_branches_names
             continue
         end
         for t in time_steps
@@ -944,7 +944,7 @@ function objective_function!(
 ) where {T <: PSY.ACBranch}
     if get_use_slacks(device_model)
         variable_up = get_variable(container, FlowActivePowerSlackUpperBound(), T)
-        # Use device names because there might be a radial network reduction
+        # Use device names because there might be a network reduction
         for name in axes(variable_up, 1)
             for t in get_time_steps(container)
                 add_to_objective_invariant_expression!(
@@ -966,7 +966,7 @@ function objective_function!(
     if get_use_slacks(device_model)
         variable_up = get_variable(container, FlowActivePowerSlackUpperBound(), T)
         variable_dn = get_variable(container, FlowActivePowerSlackLowerBound(), T)
-        # Use device names because there might be a radial network reduction
+        # Use device names because there might be a network reduction
         for name in axes(variable_up, 1)
             for t in get_time_steps(container)
                 add_to_objective_invariant_expression!(

--- a/src/devices_models/devices/common/add_to_expression.jl
+++ b/src/devices_models/devices/common/add_to_expression.jl
@@ -150,9 +150,9 @@ function add_to_expression!(
 }
     param_container = get_parameter(container, U(), V)
     multiplier = get_multiplier_array(param_container)
-    radial_network_reduction = get_radial_network_reduction(network_model)
+    network_reduction = get_network_reduction(network_model)
     for d in devices, t in get_time_steps(container)
-        bus_no = PNM.get_mapped_bus_number(radial_network_reduction, PSY.get_bus(d))
+        bus_no = PNM.get_mapped_bus_number(network_reduction, PSY.get_bus(d))
         name = PSY.get_name(d)
         _add_to_jump_expression!(
             get_expression(container, T(), PSY.ACBus)[bus_no, t],
@@ -206,9 +206,9 @@ function add_to_expression!(
     X <: PM.AbstractPowerModel,
 }
     parameter = get_parameter_array(container, U(), V)
-    radial_network_reduction = get_radial_network_reduction(network_model)
+    network_reduction = get_network_reduction(network_model)
     for d in devices, t in get_time_steps(container)
-        bus_no = PNM.get_mapped_bus_number(radial_network_reduction, PSY.get_bus(d))
+        bus_no = PNM.get_mapped_bus_number(network_reduction, PSY.get_bus(d))
         name = PSY.get_name(d)
         mult = get_expression_multiplier(U(), T(), d, W())
         _add_to_jump_expression!(
@@ -239,10 +239,10 @@ function add_to_expression!(
 }
     variable = get_variable(container, U(), V)
     expression = get_expression(container, T(), PSY.ACBus)
-    radial_network_reduction = get_radial_network_reduction(network_model)
+    network_reduction = get_network_reduction(network_model)
     for d in devices
         name = PSY.get_name(d)
-        bus_no = PNM.get_mapped_bus_number(radial_network_reduction, PSY.get_bus(d))
+        bus_no = PNM.get_mapped_bus_number(network_reduction, PSY.get_bus(d))
         for t in get_time_steps(container)
             _add_to_jump_expression!(
                 expression[bus_no, t],
@@ -370,9 +370,9 @@ function add_to_expression!(
     var = get_variable(container, U(), V)
     nodal_expr = get_expression(container, T(), PSY.ACBus)
     sys_expr = get_expression(container, T(), PSY.System)
-    radial_network_reduction = get_radial_network_reduction(network_model)
+    network_reduction = get_network_reduction(network_model)
     for d in devices
-        bus_no_to = PNM.get_mapped_bus_number(radial_network_reduction, PSY.get_arc(d).to)
+        bus_no_to = PNM.get_mapped_bus_number(network_reduction, PSY.get_arc(d).to)
         ref_bus_from = get_reference_bus(network_model, PSY.get_arc(d).from)
         ref_bus_to = get_reference_bus(network_model, PSY.get_arc(d).to)
         for t in get_time_steps(container)
@@ -406,10 +406,10 @@ function add_to_expression!(
     var = get_variable(container, U(), V)
     nodal_expr = get_expression(container, T(), PSY.ACBus)
     sys_expr = get_expression(container, T(), _system_expression_type(X))
-    radial_network_reduction = get_radial_network_reduction(network_model)
+    network_reduction = get_network_reduction(network_model)
     for d in devices
         bus_no_from =
-            PNM.get_mapped_bus_number(radial_network_reduction, PSY.get_arc(d).from)
+            PNM.get_mapped_bus_number(network_reduction, PSY.get_arc(d).from)
         ref_bus_to = get_reference_bus(network_model, PSY.get_arc(d).to)
         ref_bus_from = get_reference_bus(network_model, PSY.get_arc(d).from)
         for t in get_time_steps(container)
@@ -443,10 +443,10 @@ function add_to_expression!(
     var = get_variable(container, U(), V)
     nodal_expr = get_expression(container, T(), PSY.ACBus)
     sys_expr = get_expression(container, T(), _system_expression_type(X))
-    radial_network_reduction = get_radial_network_reduction(network_model)
+    network_reduction = get_network_reduction(network_model)
     for d in devices
         bus_no_from =
-            PNM.get_mapped_bus_number(radial_network_reduction, PSY.get_arc(d).from)
+            PNM.get_mapped_bus_number(network_reduction, PSY.get_arc(d).from)
         ref_bus_to = get_reference_bus(network_model, PSY.get_arc(d).to)
         ref_bus_from = get_reference_bus(network_model, PSY.get_arc(d).from)
         for t in get_time_steps(container)
@@ -479,10 +479,10 @@ function add_to_expression!(
 }
     var = get_variable(container, U(), V)
     nodal_expr = get_expression(container, T(), PSY.ACBus)
-    radial_network_reduction = get_radial_network_reduction(network_model)
+    network_reduction = get_network_reduction(network_model)
     for d in devices
         bus_no_from =
-            PNM.get_mapped_bus_number(radial_network_reduction, PSY.get_arc(d).from)
+            PNM.get_mapped_bus_number(network_reduction, PSY.get_arc(d).from)
         for t in get_time_steps(container)
             flow_variable = var[PSY.get_name(d), t]
             _add_to_jump_expression!(nodal_expr[bus_no_from, t], flow_variable, -1.0)
@@ -510,10 +510,10 @@ function add_to_expression!(
 }
     var = get_variable(container, U(), V)
     nodal_expr = get_expression(container, T(), PSY.ACBus)
-    radial_network_reduction = get_radial_network_reduction(network_model)
+    network_reduction = get_network_reduction(network_model)
     for d in devices
         bus_no_to =
-            PNM.get_mapped_bus_number(radial_network_reduction, PSY.get_arc(d).to)
+            PNM.get_mapped_bus_number(network_reduction, PSY.get_arc(d).to)
         for t in get_time_steps(container)
             flow_variable = var[PSY.get_name(d), t]
             _add_to_jump_expression!(nodal_expr[bus_no_to, t], flow_variable, 1.0)
@@ -541,10 +541,10 @@ function add_to_expression!(
 }
     var = get_variable(container, U(), V)
     nodal_expr = get_expression(container, T(), PSY.ACBus)
-    radial_network_reduction = get_radial_network_reduction(network_model)
+    network_reduction = get_network_reduction(network_model)
     for d in devices
         bus_no_from =
-            PNM.get_mapped_bus_number(radial_network_reduction, PSY.get_arc(d).from)
+            PNM.get_mapped_bus_number(network_reduction, PSY.get_arc(d).from)
         for t in get_time_steps(container)
             flow_variable = var[PSY.get_name(d), t]
             _add_to_jump_expression!(nodal_expr[bus_no_from, t], flow_variable, -1.0)
@@ -572,10 +572,10 @@ function add_to_expression!(
 }
     var = get_variable(container, U(), V)
     nodal_expr = get_expression(container, T(), PSY.ACBus)
-    radial_network_reduction = get_radial_network_reduction(network_model)
+    network_reduction = get_network_reduction(network_model)
     for d in devices
         bus_no_to =
-            PNM.get_mapped_bus_number(radial_network_reduction, PSY.get_arc(d).to)
+            PNM.get_mapped_bus_number(network_reduction, PSY.get_arc(d).to)
         for t in get_time_steps(container)
             flow_variable = var[PSY.get_name(d), t]
             _add_to_jump_expression!(nodal_expr[bus_no_to, t], flow_variable, -1.0)
@@ -604,10 +604,10 @@ function add_to_expression!(
     var = get_variable(container, U(), V)
     nodal_expr = get_expression(container, T(), PSY.ACBus)
     sys_expr = get_expression(container, T(), _system_expression_type(X))
-    radial_network_reduction = get_radial_network_reduction(network_model)
+    network_reduction = get_network_reduction(network_model)
     for d in devices
         bus_no_to =
-            PNM.get_mapped_bus_number(radial_network_reduction, PSY.get_arc(d).to)
+            PNM.get_mapped_bus_number(network_reduction, PSY.get_arc(d).to)
         ref_bus_to = get_reference_bus(network_model, PSY.get_arc(d).to)
         ref_bus_from = get_reference_bus(network_model, PSY.get_arc(d).from)
         for t in get_time_steps(container)
@@ -708,11 +708,11 @@ function add_to_expression!(
 }
     variable = get_variable(container, U(), V)
     expression = get_expression(container, T(), PSY.ACBus)
-    radial_network_reduction = get_radial_network_reduction(network_model)
+    network_reduction = get_network_reduction(network_model)
     for d in devices
         name = PSY.get_name(d)
         bus_no_ = PSY.get_number(PSY.get_arc(d).from)
-        bus_no = PNM.get_mapped_bus_number(radial_network_reduction, bus_no_)
+        bus_no = PNM.get_mapped_bus_number(network_reduction, bus_no_)
         for t in get_time_steps(container)
             _add_to_jump_expression!(
                 expression[bus_no, t],
@@ -743,11 +743,11 @@ function add_to_expression!(
 }
     variable = get_variable(container, U(), V)
     expression = get_expression(container, T(), PSY.ACBus)
-    radial_network_reduction = get_radial_network_reduction(network_model)
+    network_reduction = get_network_reduction(network_model)
     for d in devices
         name = PSY.get_name(d)
         bus_no_ = PSY.get_number(PSY.get_arc(d).to)
-        bus_no = PNM.get_mapped_bus_number(radial_network_reduction, bus_no_)
+        bus_no = PNM.get_mapped_bus_number(network_reduction, bus_no_)
         for t in get_time_steps(container)
             _add_to_jump_expression!(
                 expression[bus_no, t],
@@ -775,11 +775,11 @@ function add_to_expression!(
 }
     variable = get_variable(container, U(), V)
     expression = get_expression(container, T(), PSY.ACBus)
-    radial_network_reduction = get_radial_network_reduction(network_model)
+    network_reduction = get_network_reduction(network_model)
     for d in devices
         name = PSY.get_name(d)
         bus_no_ = PSY.get_number(PSY.get_bus(d))
-        bus_no = PNM.get_mapped_bus_number(radial_network_reduction, bus_no_)
+        bus_no = PNM.get_mapped_bus_number(network_reduction, bus_no_)
         for t in get_time_steps(container)
             if PSY.get_must_run(d)
                 _add_to_jump_expression!(
@@ -982,12 +982,12 @@ function add_to_expression!(
     multiplier = get_multiplier_array(param_container)
     sys_expr = get_expression(container, T(), _system_expression_type(X))
     nodal_expr = get_expression(container, T(), PSY.ACBus)
-    radial_network_reduction = get_radial_network_reduction(network_model)
+    network_reduction = get_network_reduction(network_model)
     for d in devices
         name = PSY.get_name(d)
         device_bus = PSY.get_bus(d)
         bus_no_ = PSY.get_number(device_bus)
-        bus_no = PNM.get_mapped_bus_number(radial_network_reduction, bus_no_)
+        bus_no = PNM.get_mapped_bus_number(network_reduction, bus_no_)
         ref_index = _ref_index(network_model, device_bus)
         param = get_parameter_column_refs(param_container, name)
         for t in get_time_steps(container)
@@ -1015,11 +1015,11 @@ function add_to_expression!(
     parameter = get_parameter_array(container, U(), V)
     sys_expr = get_expression(container, T(), PSY.System)
     nodal_expr = get_expression(container, T(), PSY.ACBus)
-    radial_network_reduction = get_radial_network_reduction(network_model)
+    network_reduction = get_network_reduction(network_model)
     for d in devices
         name = PSY.get_name(d)
         bus_no_ = PSY.get_number(PSY.get_bus(d))
-        bus_no = PNM.get_mapped_bus_number(radial_network_reduction, bus_no_)
+        bus_no = PNM.get_mapped_bus_number(network_reduction, bus_no_)
         mult = get_expression_multiplier(U(), T(), d, W())
         device_bus = PSY.get_bus(d)
         ref_index = _ref_index(network_model, device_bus)
@@ -1050,11 +1050,11 @@ function add_to_expression!(
     variable = get_variable(container, U(), V)
     sys_expr = get_expression(container, T(), PSY.System)
     nodal_expr = get_expression(container, T(), PSY.ACBus)
-    radial_network_reduction = get_radial_network_reduction(network_model)
+    network_reduction = get_network_reduction(network_model)
     for d in devices
         name = PSY.get_name(d)
         device_bus = PSY.get_bus(d)
-        bus_no = PNM.get_mapped_bus_number(radial_network_reduction, device_bus)
+        bus_no = PNM.get_mapped_bus_number(network_reduction, device_bus)
         ref_index = _ref_index(network_model, device_bus)
         for t in get_time_steps(container)
             _add_to_jump_expression!(
@@ -1088,12 +1088,12 @@ function add_to_expression!(
     variable = get_variable(container, U(), V)
     area_expr = get_expression(container, T(), PSY.Area)
     nodal_expr = get_expression(container, T(), PSY.ACBus)
-    radial_network_reduction = get_radial_network_reduction(network_model)
+    network_reduction = get_network_reduction(network_model)
     for d in devices
         name = PSY.get_name(d)
         device_bus = PSY.get_bus(d)
         area_name = PSY.get_name(PSY.get_area(device_bus))
-        bus_no = PNM.get_mapped_bus_number(radial_network_reduction, device_bus)
+        bus_no = PNM.get_mapped_bus_number(network_reduction, device_bus)
         for t in get_time_steps(container)
             _add_to_jump_expression!(
                 area_expr[area_name, t],
@@ -1126,10 +1126,10 @@ function add_to_expression!(
     variable = get_variable(container, U(), V)
     sys_expr = get_expression(container, T(), _system_expression_type(PTDFPowerModel))
     nodal_expr = get_expression(container, T(), PSY.ACBus)
-    radial_network_reduction = get_radial_network_reduction(network_model)
+    network_reduction = get_network_reduction(network_model)
     for d in devices
         name = PSY.get_name(d)
-        bus_no = PNM.get_mapped_bus_number(radial_network_reduction, PSY.get_bus(d))
+        bus_no = PNM.get_mapped_bus_number(network_reduction, PSY.get_bus(d))
         ref_index = _ref_index(network_model, PSY.get_bus(d))
         for t in get_time_steps(container)
             _add_to_jump_expression!(
@@ -1166,11 +1166,11 @@ function add_to_expression!(
 }
     var = get_variable(container, U(), V)
     expression = get_expression(container, T(), PSY.ACBus)
-    radial_network_reduction = get_radial_network_reduction(network_model)
+    network_reduction = get_network_reduction(network_model)
     for d in devices
         bus_no_from =
-            PNM.get_mapped_bus_number(radial_network_reduction, PSY.get_arc(d).from)
-        bus_no_to = PNM.get_mapped_bus_number(radial_network_reduction, PSY.get_arc(d).to)
+            PNM.get_mapped_bus_number(network_reduction, PSY.get_arc(d).from)
+        bus_no_to = PNM.get_mapped_bus_number(network_reduction, PSY.get_arc(d).to)
         for t in get_time_steps(container)
             flow_variable = var[PSY.get_name(d), t]
             _add_to_jump_expression!(
@@ -1240,11 +1240,11 @@ function add_to_expression!(
     var = get_variable(container, U(), V)
     nodal_expr = get_expression(container, T(), PSY.ACBus)
     sys_expr = get_expression(container, T(), PSY.System)
-    radial_network_reduction = get_radial_network_reduction(network_model)
+    network_reduction = get_network_reduction(network_model)
     for d in devices
         bus_no_from =
-            PNM.get_mapped_bus_number(radial_network_reduction, PSY.get_arc(d).from)
-        bus_no_to = PNM.get_mapped_bus_number(radial_network_reduction, PSY.get_arc(d).to)
+            PNM.get_mapped_bus_number(network_reduction, PSY.get_arc(d).from)
+        bus_no_to = PNM.get_mapped_bus_number(network_reduction, PSY.get_arc(d).to)
         ref_bus_from = get_reference_bus(network_model, PSY.get_arc(d).from)
         ref_bus_to = get_reference_bus(network_model, PSY.get_arc(d).to)
         for t in get_time_steps(container)
@@ -1316,11 +1316,11 @@ function add_to_expression!(
 ) where {T <: ActivePowerBalance, U <: PhaseShifterAngle, V <: PhaseAngleControl}
     var = get_variable(container, U(), PSY.PhaseShiftingTransformer)
     expression = get_expression(container, T(), PSY.ACBus)
-    radial_network_reduction = get_radial_network_reduction(network_model)
+    network_reduction = get_network_reduction(network_model)
     for d in devices
         bus_no_from =
-            PNM.get_mapped_bus_number(radial_network_reduction, PSY.get_arc(d).from)
-        bus_no_to = PNM.get_mapped_bus_number(radial_network_reduction, PSY.get_arc(d).to)
+            PNM.get_mapped_bus_number(network_reduction, PSY.get_arc(d).from)
+        bus_no_to = PNM.get_mapped_bus_number(network_reduction, PSY.get_arc(d).to)
         for t in get_time_steps(container)
             flow_variable = var[PSY.get_name(d), t]
             _add_to_jump_expression!(

--- a/src/initial_conditions/initialization.jl
+++ b/src/initial_conditions/initialization.jl
@@ -9,8 +9,8 @@ function get_initial_conditions_template(model::OperationModel)
             get_network_model(model.template),
         ),
     )
-    network_model.radial_network_reduction =
-        get_radial_network_reduction(get_network_model(model.template))
+    network_model.network_reduction =
+        get_network_reduction(get_network_model(model.template))
     network_model.subnetworks = get_subnetworks(get_network_model(model.template))
     # Initialization does not support PowerFlow evaluation
     network_model.power_flow_evaluation = Vector{PFS.PowerFlowEvaluationModel}[]

--- a/src/network_models/network_slack_variables.jl
+++ b/src/network_models/network_slack_variables.jl
@@ -62,12 +62,12 @@ function add_variables!(
     U <: PM.AbstractActivePowerModel,
 }
     time_steps = get_time_steps(container)
-    radial_network_reduction = get_radial_network_reduction(network_model)
-    if isempty(radial_network_reduction)
+    network_reduction = get_network_reduction(network_model)
+    if isempty(network_reduction)
         bus_numbers =
             PSY.get_number.(get_available_components(network_model, PSY.ACBus, sys))
     else
-        bus_numbers = collect(keys(PNM.get_bus_reduction_map(radial_network_reduction)))
+        bus_numbers = collect(keys(PNM.get_bus_reduction_map(network_reduction)))
     end
 
     variable = add_variable_container!(container, T(), PSY.ACBus, bus_numbers, time_steps)
@@ -91,12 +91,12 @@ function add_variables!(
     U <: PM.AbstractPowerModel,
 }
     time_steps = get_time_steps(container)
-    radial_network_reduction = get_radial_network_reduction(network_model)
-    if isempty(radial_network_reduction)
+    network_reduction = get_network_reduction(network_model)
+    if isempty(network_reduction)
         bus_numbers =
             PSY.get_number.(get_available_components(network_model, PSY.ACBus, sys))
     else
-        bus_numbers = collect(keys(PNM.get_bus_reduction_map(radial_network_reduction)))
+        bus_numbers = collect(keys(PNM.get_bus_reduction_map(network_reduction)))
     end
     variable_active =
         add_variable_container!(container, T(), PSY.ACBus, "P", bus_numbers, time_steps)

--- a/src/network_models/pm_translator.jl
+++ b/src/network_models/pm_translator.jl
@@ -398,8 +398,8 @@ function get_branches_to_pm(
     PM_branches = Dict{String, Any}()
     PMmap_br = Dict{PM_MAP_TUPLE, T}()
 
-    radial_network_reduction = get_radial_network_reduction(network_model)
-    radial_branches_names = PNM.get_radial_branches(radial_network_reduction)
+    network_reduction = get_network_reduction(network_model)
+    removed_branches_names = PNM.get_removed_branches(network_reduction)
     for (d, device_model) in branch_template
         comp_type = get_component_type(device_model)
         if comp_type <: TwoTerminalHVDCTypes
@@ -408,7 +408,7 @@ function get_branches_to_pm(
         !(comp_type <: T) && continue
         start_idx += length(PM_branches)
         for (i, branch) in enumerate(get_available_components(device_model, sys))
-            if PSY.get_name(branch) ∈ radial_branches_names
+            if PSY.get_name(branch) ∈ removed_branches_names
                 @debug "Skipping branch $(PSY.get_name(branch)) since it is radial"
                 continue
             end

--- a/src/network_models/powermodels_interface.jl
+++ b/src/network_models/powermodels_interface.jl
@@ -250,12 +250,12 @@ function powermodels_network!(
     pm_data, PM_map = pass_to_pm(sys, template, time_steps[end])
 
     network_model = get_network_model(template)
-    radial_network_reduction = get_radial_network_reduction(network_model)
-    if isempty(radial_network_reduction)
+    network_reduction = get_network_reduction(network_model)
+    if isempty(network_reduction)
         ac_bus_numbers =
             PSY.get_number.(get_available_components(network_model, PSY.ACBus, sys))
     else
-        bus_reduction_map = PNM.get_bus_reduction_map(radial_network_reduction)
+        bus_reduction_map = PNM.get_bus_reduction_map(network_reduction)
         ac_bus_numbers = collect(keys(bus_reduction_map))
     end
 
@@ -290,12 +290,12 @@ function powermodels_network!(
     pm_data, PM_map = pass_to_pm(sys, template, time_steps[end])
 
     network_model = get_network_model(template)
-    radial_network_reduction = get_radial_network_reduction(network_model)
-    if isempty(radial_network_reduction)
+    network_reduction = get_network_reduction(network_model)
+    if isempty(network_reduction)
         ac_bus_numbers =
             PSY.get_number.(get_available_components(network_model, PSY.ACBus, sys))
     else
-        bus_reduction_map = PNM.get_bus_reduction_map(radial_network_reduction)
+        bus_reduction_map = PNM.get_bus_reduction_map(network_reduction)
         ac_bus_numbers = collect(keys(bus_reduction_map))
     end
 


### PR DESCRIPTION
Makes compatible with the `psy5` branch in `PowerNetworkMatrices.jl` by changing radial reduction to network reduction. 
There are still a few tests with failures:
`Line and Monitored Line models with slacks`
`MarketBidCost with time series startup and shutdown, ThermalStandard `
`Test simulation partitions`
