### PR TITLE
Add `available` to `ACBus` instantiation

### DIFF
--- a/test/test_model_decision.jl
+++ b/test/test_model_decision.jl
@@ -629,6 +629,7 @@ end
         ACBus(
             10,
             "node_none",
+            true,
             "ISOLATED",
             0,
             1.0,


### PR DESCRIPTION
A tiny PR to account for the fact that the `ACBus` constructor now takes a mandatory positional argument `available::bool`.