### PR TITLE
initial condition data exception for 3D variables

### DIFF
--- a/src/core/optimization_container.jl
+++ b/src/core/optimization_container.jl
@@ -1664,6 +1664,10 @@ function write_initial_conditions_data!(
             if field == STORE_CONTAINER_PARAMETERS
                 ic_data_dict[key] = ic_container_dict[key]
             else
+            #@show key
+            @show vkey = typeof(key).parameters[1]
+                if should_write_resulting_value(vkey) == false
+                    continue end
                 ic_data_dict[key] = to_dataframe(jump_value.(field_container), key)
             end
         end


### PR DESCRIPTION
Exception for writing initial condition data to a DataFrame, useful when we have 3d variable such as HydroTurbineFlowRateVariable