### PR TITLE
address gabriel's comments

### DIFF
--- a/src/core/power_flow_data_wrapper.jl
+++ b/src/core/power_flow_data_wrapper.jl
@@ -16,12 +16,15 @@ check_network_reduction(::PFS.SystemPowerFlowContainer) = nothing
 
 function check_network_reduction(pfd::PFS.PowerFlowData)
     nrd = PFS.get_network_reduction_data(pfd)
-    if length(PNM.get_reverse_bus_search_map(nrd)) != 0
+    if !isempty(PNM.get_reductions(nrd))
         throw(
             IS.NotImplementedError(
-                "Network reduction is not supported in PowerSimulations.jl.",
+                "Network reductions of types $(PNM.get_reductions(nrd)) are not supported " *
+                "in PowerSimulations.jl.",
             ),
         )
+    elseif length(PNM.get_reverse_bus_search_map(nrd)) != 0
+        @error("Buses are reduced, due to breaker-switches. This will likely cause errors.")
     end
     return
 end


### PR DESCRIPTION
Address Gabriel's comments on previous PR.

Also I split the "there's a network reduction" error into 2 cases: if there's just a breaker-switch, log an error but continue; if there's a full-fledged network reduction, throw a `NotImplemented` error as before.