### PR TITLE
Mb/interface double circuit

### DIFF
--- a/src/core/network_model.jl
+++ b/src/core/network_model.jl
@@ -177,6 +177,7 @@ function instantiate_network_model!(
     model::NetworkModel{AreaBalancePowerModel},
     sys::PSY.System,
 )
+    PNM.populate_branch_maps_by_type!(model.network_reduction)
     return
 end
 

--- a/src/devices_models/devices/AC_branches.jl
+++ b/src/devices_models/devices/AC_branches.jl
@@ -403,7 +403,7 @@ end
 ################################## Rate Limits constraint_infos ############################
 
 function get_rating(double_circuit::Set{PSY.ACTransmission})
-    return minimum([PSY.get_rating(circuit) for circuit in double_circuit])
+    return sum([PSY.get_rating(circuit) for circuit in double_circuit])
 end
 function get_rating(series_chain::Vector{Any})
     return minimum([get_rating(segment) for segment in series_chain])

--- a/src/services_models/services_constructor.jl
+++ b/src/services_models/services_constructor.jl
@@ -601,6 +601,7 @@ function construct_service!(
         FlowActivePowerVariable,
         service,
         model,
+        network_model,
     )
 
     if get_use_slacks(model)
@@ -695,6 +696,7 @@ function construct_service!(
         FlowActivePowerVariable,
         service,
         model,
+        network_model,
     )
 
     if get_use_slacks(model)

--- a/test/test_services_constructor.jl
+++ b/test/test_services_constructor.jl
@@ -819,7 +819,7 @@ end
         available = true,
         active_power_flow_limits = (min = 0.0, max = 1.0),
         violation_penalty = 1000.0,
-        direction_mapping = Dict("A33-1" => 1,  "A33-2" => 1),
+        direction_mapping = Dict("A33-1" => 1, "A33-2" => 1),
     )
     add_service!(
         sys_rts_da,
@@ -856,7 +856,7 @@ end
           PSI.ModelBuildStatus.BUILT
     @test solve!(ps_model) == PSI.RunStatus.SUCCESSFULLY_FINALIZED
 
-    moi_tests(ps_model, 10944, 0, 2136, 1416, 4896, false)
+    moi_tests(ps_model, 10944, 0, 2160, 1440, 4896, false)
 
     opt_container = PSI.get_optimization_container(ps_model)
     copper_plate_constraints =
@@ -867,8 +867,8 @@ end
         PSI.get_constraint(opt_container, InterfaceFlowLimit(), TransmissionInterface, "ub")
     interchange_constraints_lb =
         PSI.get_constraint(opt_container, InterfaceFlowLimit(), TransmissionInterface, "lb")
-    @test size(interchange_constraints_ub) == (1, 24)
-    @test size(interchange_constraints_lb) == (1, 24)
+    @test size(interchange_constraints_ub) == (2, 24)
+    @test size(interchange_constraints_lb) == (2, 24)
 
     interchange_constraints_ub["interface1_2_3", 1]
     # psi_checksolve_test(ps_model, [MOI.OPTIMAL], 482055, 1)
@@ -883,4 +883,147 @@ end
     for i in 1:24
         @test interface_results[!, "interface1_2_3"][i] <= 100.0 + PSI.ABSOLUTE_TOLERANCE
     end
+end
+
+@testset "Test bad data for interfaces with reductions" begin
+    sys_rts_da = build_system(PSISystems, "modified_RTS_GMLC_DA_sys")
+    transform_single_time_series!(sys_rts_da, Hour(24), Hour(1))
+
+    # Add an interface on a double circuit: 
+    double_circuit_1 = get_component(Line, sys_rts_da, "A33-1")
+    double_circuit_2 = get_component(Line, sys_rts_da, "A33-2")
+    interface_double_circuit = TransmissionInterface(;
+        name = "interface_double_circuit",
+        available = true,
+        active_power_flow_limits = (min = 0.0, max = 1.0),
+        violation_penalty = 1000.0,
+        direction_mapping = Dict("A33-1" => 1, "A33-2" => 1),
+    )
+    add_service!(
+        sys_rts_da,
+        interface_double_circuit,
+        [double_circuit_1, double_circuit_2],
+    )
+
+    # Add interface on a series chain: 
+    series_chain_1 = get_component(Line, sys_rts_da, "CA-1")
+    series_chain_2 = get_component(Line, sys_rts_da, "C35")
+    interface_series_chain = TransmissionInterface(;
+        name = "interface_series_chain",
+        available = true,
+        active_power_flow_limits = (min = 0.0, max = 1.0),
+        violation_penalty = 1000.0,
+        direction_mapping = Dict("CA-1" => -1, "C35" => -1),
+    )
+    add_service!(
+        sys_rts_da,
+        interface_series_chain,
+        [series_chain_1, series_chain_2],
+    )
+    ptdf = PTDF(sys_rts_da; network_reductions = NetworkReduction[DegreeTwoReduction()])
+    template = ProblemTemplate(
+        NetworkModel(
+            AreaPTDFPowerModel;
+            PTDF_matrix = ptdf,
+            reduce_degree_two_branches = true,
+            use_slacks = true,
+        ),
+    )
+    set_device_model!(template, ThermalStandard, ThermalDispatchNoMin)
+    set_device_model!(template, RenewableDispatch, RenewableFullDispatch)
+    set_device_model!(template, PowerLoad, StaticPowerLoad)
+    set_device_model!(template, RenewableNonDispatch, FixedOutput)
+    set_device_model!(template, HydroDispatch, HydroDispatchRunOfRiver)
+    set_device_model!(template, Line, StaticBranchUnbounded)
+    set_device_model!(
+        template,
+        DeviceModel(AreaInterchange, StaticBranchUnbounded; use_slacks = false),
+    )
+    set_service_model!(
+        template,
+        ServiceModel(TransmissionInterface, ConstantMaxInterfaceFlow),
+    )
+    ps_model =
+        DecisionModel(
+            template,
+            sys_rts_da;
+            resolution = Hour(1),
+            optimizer = HiGHS_optimizer,
+            store_variable_names = true,
+            optimizer_solve_log_print = true,
+        )
+
+    @test build!(ps_model; output_dir = mktempdir(; cleanup = true)) ==
+          PSI.ModelBuildStatus.BUILT
+
+    # Test bad direction data for interface on double circuit: 
+    set_direction_mapping!(interface_series_chain, Dict("CA-1" => 1, "C35" => -1))
+    ps_model =
+        DecisionModel(
+            template,
+            sys_rts_da;
+            resolution = Hour(1),
+            optimizer = HiGHS_optimizer,
+            store_variable_names = true,
+            optimizer_solve_log_print = true,
+        )
+    @test build!(
+        ps_model;
+        console_level = Logging.AboveMaxLevel,  # Ignore expected errors.
+        output_dir = mktempdir(; cleanup = true),
+    ) == PSI.ModelBuildStatus.FAILED
+
+    # Test bad direction data for interface on series chain: 
+    set_direction_mapping!(interface_series_chain, Dict("CA-1" => 1, "C35" => 1))
+    set_direction_mapping!(interface_double_circuit, Dict("A33-1" => 1, "A33-2" => -1))
+    ps_model =
+        DecisionModel(
+            template,
+            sys_rts_da;
+            resolution = Hour(1),
+            optimizer = HiGHS_optimizer,
+            store_variable_names = true,
+            optimizer_solve_log_print = true,
+        )
+    @test build!(
+        ps_model;
+        console_level = Logging.AboveMaxLevel,  # Ignore expected errors.
+        output_dir = mktempdir(; cleanup = true),
+    ) == PSI.ModelBuildStatus.FAILED
+    set_direction_mapping!(interface_double_circuit, Dict("A33-1" => 1, "A33-2" => 1))
+
+    # Test only including part of a double circuit in an interface: 
+    pop!(get_services(double_circuit_1))
+    ps_model =
+        DecisionModel(
+            template,
+            sys_rts_da;
+            resolution = Hour(1),
+            optimizer = HiGHS_optimizer,
+            store_variable_names = true,
+            optimizer_solve_log_print = true,
+        )
+    @test build!(
+        ps_model;
+        console_level = Logging.AboveMaxLevel,  # Ignore expected errors.
+        output_dir = mktempdir(; cleanup = true),
+    ) == PSI.ModelBuildStatus.FAILED
+
+    # Test only including part of a series chain in an interface: 
+    push!(get_services(double_circuit_1), interface_double_circuit)
+    pop!(get_services(series_chain_1))
+    ps_model =
+        DecisionModel(
+            template,
+            sys_rts_da;
+            resolution = Hour(1),
+            optimizer = HiGHS_optimizer,
+            store_variable_names = true,
+            optimizer_solve_log_print = true,
+        )
+    @test build!(
+        ps_model;
+        console_level = Logging.AboveMaxLevel,  # Ignore expected errors.
+        output_dir = mktempdir(; cleanup = true),
+    ) == PSI.ModelBuildStatus.FAILED
 end


### PR DESCRIPTION
- Uses the network reduction maps when adding to interface expressions. 
- Adds tests for adding an interface to a double circuit and series reductions (including testing for bad user data input).
- Changes the rating of a double circuit to be the sum of the circuit ratings.
- Adds a test that branch bounds are set as expected for reductions (parallel and series chain)